### PR TITLE
Activate codecov coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ install:
   - scons build=fast prefix="${MYPREFIX}" test_installed=true alltests
   - MYALLTESTSFAST=$(ls -t ${PWD}/build/fast*/tests/alltests | head -1)
   - scons build=debug lib alltests
+  - scons build=coverage lib alltests
 
 
 before_script:
@@ -120,8 +121,9 @@ script:
   - scons -Q build=debug test
   - scons -Q build=debug enable_objcryst=false test
   - ${MYALLTESTSFAST}
+  - scons -Q build=coverage test
 
 
-#after_success:
-# - pip install $MYPIPFLAGS codecov
-# - codecov
+after_success:
+  - pip install $MYPIPFLAGS codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/diffpy/libdiffpy.svg?branch=master)](https://travis-ci.org/diffpy/libdiffpy)
+[![codecov](https://codecov.io/gh/diffpy/libdiffpy/branch/master/graph/badge.svg)](https://codecov.io/gh/diffpy/libdiffpy)
 
 # libdiffpy
 


### PR DESCRIPTION
Compile and test with code coverage tracking in travis.
Upload coverage data to codecov.io.
Add codecov report badge to README.md.