### PR TITLE
add `uisowidth` attribute to ConstantPeakWidth class

### DIFF
--- a/src/diffpy/Attributes.ipp
+++ b/src/diffpy/Attributes.ipp
@@ -30,6 +30,73 @@ namespace attributes {
 // class DoubleAttribute
 //////////////////////////////////////////////////////////////////////////////
 
+template <class T>
+class GetSetTypes
+{
+    public:
+
+        // getter types
+        typedef double(*GF)(const T*);
+        typedef double(T::*GMF)() const;
+        typedef const double&(T::*GMFR)() const;
+
+        // setter types
+        typedef void(*SF)(T*, const double&);
+        typedef void(T::*SMF)(double);
+        typedef void(T::*SMFR)(const double&);
+
+};
+
+
+class GetSetTools
+{
+    public:
+
+        template <class T>
+        static double
+        callgetter(const T* obj, typename GetSetTypes<T>::GF getter)
+        {
+            return getter(obj);
+        }
+
+        template <class T>
+        static double
+        callgetter(const T* obj, typename GetSetTypes<T>::GMF getter)
+        {
+            return (obj->*getter)();
+        }
+
+        template <class T>
+        static double
+        callgetter(const T* obj, typename GetSetTypes<T>::GMFR getter)
+        {
+            return (obj->*getter)();
+        }
+
+        template <class T>
+        static void
+        callsetter(T* obj, typename GetSetTypes<T>::SF setter, const double& x)
+        {
+            setter(obj, x);
+        }
+
+        template <class T>
+        static void
+        callsetter(T* obj, typename GetSetTypes<T>::SMF setter, const double& x)
+        {
+            (obj->*setter)(x);
+        }
+
+        template <class T>
+        static void
+        callsetter(T* obj, typename GetSetTypes<T>::SMFR setter, const double& x)
+        {
+            (obj->*setter)(x);
+        }
+
+};
+
+
 template <class T, class Getter, class Setter>
 class DoubleAttribute : public BaseDoubleAttribute
 {
@@ -46,7 +113,7 @@ class DoubleAttribute : public BaseDoubleAttribute
         {
             const T* tobj = dynamic_cast<const T*>(obj);
             assert(tobj);
-            double rv = (tobj->*mgetter)();
+            double rv = GetSetTools::callgetter(tobj, mgetter);
             return rv;
         }
 
@@ -55,7 +122,7 @@ class DoubleAttribute : public BaseDoubleAttribute
             if (this->isreadonly())  throwDoubleAttributeReadOnly();
             T* tobj = dynamic_cast<T*>(obj);
             assert(tobj);
-            (tobj->*msetter)(value);
+            GetSetTools::callsetter(tobj, msetter, value);
         }
 
         bool isreadonly() const

--- a/src/diffpy/features.tpl
+++ b/src/diffpy/features.tpl
@@ -25,8 +25,9 @@
 # define DIFFPY_HAS_OBJCRYST
 #endif
 
-// FIXME -- temporary feature, remove when released
+// FIXME -- temporary features, remove when released
 #define DIFFPY_DEV_PEAKWIDTHMODEL_SERIALIZATION
+#define DIFFPY_DEV_CONSTANTPEAKWIDTH_UISOWIDTH
 
 #endif  // FEATURES_HPP_INCLUDED
 

--- a/src/diffpy/srreal/ConstantPeakWidth.cpp
+++ b/src/diffpy/srreal/ConstantPeakWidth.cpp
@@ -18,11 +18,34 @@
 
 #include <diffpy/srreal/ConstantPeakWidth.hpp>
 #include <diffpy/serialization.ipp>
+#include <diffpy/validators.hpp>
 
 namespace diffpy {
 namespace srreal {
 
 using namespace std;
+
+// Local Helpers -------------------------------------------------------------
+
+namespace {
+
+using diffpy::mathutils::GAUSS_SIGMA_TO_FWHM;
+using diffpy::validators::ensureNonNegative;
+
+double getuisowidth(const ConstantPeakWidth* ppwm)
+{
+    const double rmsd = ppwm->getWidth() / GAUSS_SIGMA_TO_FWHM;
+    return 0.5 * rmsd * rmsd;
+}
+
+void setuisowidth(ConstantPeakWidth* ppwm, const double& uiso)
+{
+    ensureNonNegative("uisowidth", uiso);
+    const double fwhm = GAUSS_SIGMA_TO_FWHM * sqrt(2.0 * uiso);
+    ppwm->setWidth(fwhm);
+}
+
+}   // namespace
 
 // Constructors --------------------------------------------------------------
 
@@ -30,6 +53,8 @@ ConstantPeakWidth::ConstantPeakWidth() : mwidth(0.0)
 {
     this->registerDoubleAttribute("width", this,
             &ConstantPeakWidth::getWidth, &ConstantPeakWidth::setWidth);
+    this->registerDoubleAttribute("uisowidth", this,
+            &getuisowidth, &setuisowidth);
 }
 
 

--- a/src/diffpy/srreal/ConstantPeakWidth.cpp
+++ b/src/diffpy/srreal/ConstantPeakWidth.cpp
@@ -18,7 +18,6 @@
 
 #include <diffpy/srreal/ConstantPeakWidth.hpp>
 #include <diffpy/serialization.ipp>
-#include <diffpy/validators.hpp>
 
 namespace diffpy {
 namespace srreal {
@@ -30,18 +29,19 @@ using namespace std;
 namespace {
 
 using diffpy::mathutils::GAUSS_SIGMA_TO_FWHM;
-using diffpy::validators::ensureNonNegative;
 
 double getuisowidth(const ConstantPeakWidth* ppwm)
 {
     const double rmsd = ppwm->getWidth() / GAUSS_SIGMA_TO_FWHM;
-    return 0.5 * rmsd * rmsd;
+    const int pm = (rmsd >= 0) ? +1 : -1;
+    return pm * 0.5 * rmsd * rmsd;
 }
 
 void setuisowidth(ConstantPeakWidth* ppwm, const double& uiso)
 {
-    ensureNonNegative("uisowidth", uiso);
-    const double fwhm = GAUSS_SIGMA_TO_FWHM * sqrt(2.0 * uiso);
+    const int pm = (uiso >= 0) ? +1 : -1;
+    const double uisoplus = pm * uiso;
+    const double fwhm = pm * GAUSS_SIGMA_TO_FWHM * sqrt(2.0 * uisoplus);
     ppwm->setWidth(fwhm);
 }
 

--- a/src/diffpy/srreal/ConstantPeakWidth.cpp
+++ b/src/diffpy/srreal/ConstantPeakWidth.cpp
@@ -29,6 +29,8 @@ using namespace std;
 namespace {
 
 using diffpy::mathutils::GAUSS_SIGMA_TO_FWHM;
+const double UtoB = 8 * M_PI * M_PI;
+
 
 double getuisowidth(const ConstantPeakWidth* ppwm)
 {
@@ -45,6 +47,17 @@ void setuisowidth(ConstantPeakWidth* ppwm, const double& uiso)
     ppwm->setWidth(fwhm);
 }
 
+
+double getbisowidth(const ConstantPeakWidth* ppwm)
+{
+    return UtoB * getuisowidth(ppwm);
+}
+
+void setbisowidth(ConstantPeakWidth* ppwm, const double& biso)
+{
+    setuisowidth(ppwm, biso / UtoB);
+}
+
 }   // namespace
 
 // Constructors --------------------------------------------------------------
@@ -53,6 +66,8 @@ ConstantPeakWidth::ConstantPeakWidth() : mwidth(0.0)
 {
     this->registerDoubleAttribute("width", this,
             &ConstantPeakWidth::getWidth, &ConstantPeakWidth::setWidth);
+    this->registerDoubleAttribute("bisowidth", this,
+            &getbisowidth, &setbisowidth);
     this->registerDoubleAttribute("uisowidth", this,
             &getuisowidth, &setuisowidth);
 }

--- a/src/tests/TestPeakWidthModel.hpp
+++ b/src/tests/TestPeakWidthModel.hpp
@@ -19,6 +19,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include <diffpy/srreal/PeakWidthModel.hpp>
+#include <diffpy/srreal/ConstantPeakWidth.hpp>
 #include <diffpy/srreal/DebyeWallerPeakWidth.hpp>
 #include <diffpy/srreal/JeongPeakWidth.hpp>
 #include <diffpy/srreal/AtomicStructureAdapter.hpp>
@@ -38,6 +39,8 @@ class TestPeakWidthModel : public CxxTest::TestSuite
     private:
 
         // data
+        PeakWidthModelPtr mcnpw;
+        ConstantPeakWidth* mccnpw;
         PeakWidthModelPtr mdwpw;
         PeakWidthModelPtr mjepw;
         JeongPeakWidth* mcjepw;
@@ -60,6 +63,8 @@ class TestPeakWidthModel : public CxxTest::TestSuite
 
         void setUp()
         {
+            mcnpw = PeakWidthModel::createByType("constant");
+            mccnpw = static_cast<ConstantPeakWidth*>(mcnpw.get());
             mdwpw = PeakWidthModel::createByType("debye-waller");
             mjepw = PeakWidthModel::createByType("jeong");
             mcjepw = static_cast<JeongPeakWidth*>(mjepw.get());
@@ -69,6 +74,7 @@ class TestPeakWidthModel : public CxxTest::TestSuite
 
         void test_clone()
         {
+            TS_ASSERT_EQUALS(mcnpw->type(), mcnpw->clone()->type());
             TS_ASSERT_EQUALS(mdwpw->type(), mdwpw->clone()->type());
             TS_ASSERT_EQUALS(mjepw->type(), mjepw->clone()->type());
         }
@@ -121,6 +127,53 @@ class TestPeakWidthModel : public CxxTest::TestSuite
             TS_ASSERT_EQUALS(2.2, pwm2->getDoubleAttr("delta2"));
             TS_ASSERT_EQUALS(0.03, pwm2->getDoubleAttr("qbroad"));
         }
+
+
+        void test_CPWM_attributes()
+        {
+            TS_ASSERT_EQUALS("constant", mcnpw->type());
+            TS_ASSERT(mcnpw->hasDoubleAttr("width"));
+            TS_ASSERT(mcnpw->hasDoubleAttr("uisowidth"));
+            TS_ASSERT_EQUALS(2, mcnpw->namesOfDoubleAttributes().size());
+            mccnpw->setWidth(0.1);
+            TS_ASSERT_EQUALS(0.1, mcnpw->getDoubleAttr("width"));
+            TS_ASSERT_EQUALS(0.1, mcnpw->maxWidth(dimer(), 0, 4));
+            const double uw0 = mcnpw->getDoubleAttr("uisowidth");
+            mccnpw->setWidth(2 * mccnpw->getWidth());
+            TS_ASSERT_DELTA(4 * uw0, mcnpw->getDoubleAttr("uisowidth"), meps);
+        }
+
+
+        void test_CPWM_uisowidth()
+        {
+            StructureAdapterPtr adpt = dimer();
+            BaseBondGeneratorPtr bnds = adpt->createBondGenerator();
+            PeakWidthModelPtr dwpw(new DebyeWallerPeakWidth);
+            bnds->setRmax(2.0);
+            bnds->rewind();
+            const double w0 = dwpw->calculate(*bnds);
+            TS_ASSERT_EQUALS(0.0, mcnpw->calculate(*bnds));
+            mcnpw->setDoubleAttr("uisowidth", tuiso);
+            TS_ASSERT_DELTA(w0, mcnpw->calculate(*bnds), meps);
+            mcnpw->setDoubleAttr("uisowidth", -tuiso);
+            TS_ASSERT_DELTA(-tuiso, mcnpw->getDoubleAttr("uisowidth"), meps);
+            TS_ASSERT_DELTA(-w0, mcnpw->getDoubleAttr("width"), meps);
+        }
+
+
+        void test_CPWM_serialization()
+        {
+            PeakWidthModelPtr pwm1 = dumpandload(mcnpw);
+            TS_ASSERT_EQUALS("constant", pwm1->type());
+            TS_ASSERT_EQUALS(0.0, pwm1->getDoubleAttr("width"));
+            mcnpw->setDoubleAttr("width", 0.1);
+            double uw0 = mcnpw->getDoubleAttr("uisowidth");
+            PeakWidthModelPtr pwm2 = dumpandload(mcnpw);
+            TS_ASSERT_EQUALS(0.1, pwm2->getDoubleAttr("width"));
+            TS_ASSERT_DELTA(uw0, pwm2->getDoubleAttr("uisowidth"), meps);
+        }
+
+
 
 };  // class TestPeakWidthModel
 

--- a/src/tests/TestPeakWidthModel.hpp
+++ b/src/tests/TestPeakWidthModel.hpp
@@ -29,6 +29,7 @@ namespace diffpy {
 namespace srreal {
 
 const double tuiso = 0.004;
+const double UtoB = 8 * M_PI * M_PI;
 
 //////////////////////////////////////////////////////////////////////////////
 // class TestPeakWidthModel
@@ -133,14 +134,28 @@ class TestPeakWidthModel : public CxxTest::TestSuite
         {
             TS_ASSERT_EQUALS("constant", mcnpw->type());
             TS_ASSERT(mcnpw->hasDoubleAttr("width"));
+            TS_ASSERT(mcnpw->hasDoubleAttr("bisowidth"));
             TS_ASSERT(mcnpw->hasDoubleAttr("uisowidth"));
-            TS_ASSERT_EQUALS(2, mcnpw->namesOfDoubleAttributes().size());
+            TS_ASSERT_EQUALS(3, mcnpw->namesOfDoubleAttributes().size());
             mccnpw->setWidth(0.1);
             TS_ASSERT_EQUALS(0.1, mcnpw->getDoubleAttr("width"));
             TS_ASSERT_EQUALS(0.1, mcnpw->maxWidth(dimer(), 0, 4));
+            const double bw0 = mcnpw->getDoubleAttr("bisowidth");
             const double uw0 = mcnpw->getDoubleAttr("uisowidth");
             mccnpw->setWidth(2 * mccnpw->getWidth());
+            TS_ASSERT_DELTA(bw0, UtoB * uw0, meps);
+            TS_ASSERT_DELTA(4 * bw0, mcnpw->getDoubleAttr("bisowidth"), meps);
             TS_ASSERT_DELTA(4 * uw0, mcnpw->getDoubleAttr("uisowidth"), meps);
+        }
+
+
+        void test_CPWM_bisowidth()
+        {
+            const double biso = UtoB * tuiso;
+            mcnpw->setDoubleAttr("bisowidth", biso);
+            TS_ASSERT_DELTA(tuiso, mcnpw->getDoubleAttr("uisowidth"), meps);
+            mcnpw->setDoubleAttr("uisowidth", -tuiso);
+            TS_ASSERT_DELTA(-biso, mcnpw->getDoubleAttr("bisowidth"), meps);
         }
 
 

--- a/src/tests/TestPeakWidthModel.hpp
+++ b/src/tests/TestPeakWidthModel.hpp
@@ -74,9 +74,9 @@ class TestPeakWidthModel : public CxxTest::TestSuite
 
         void test_clone()
         {
-            TS_ASSERT_EQUALS(mcnpw->type(), mcnpw->clone()->type());
-            TS_ASSERT_EQUALS(mdwpw->type(), mdwpw->clone()->type());
-            TS_ASSERT_EQUALS(mjepw->type(), mjepw->clone()->type());
+            TS_ASSERT_EQUALS("constant", mcnpw->clone()->type());
+            TS_ASSERT_EQUALS("debye-waller", mdwpw->clone()->type());
+            TS_ASSERT_EQUALS("jeong", mjepw->clone()->type());
         }
 
 


### PR DESCRIPTION
## TODO

- [x] add test that compares with Debye-Waller result from a 2-atom-same-Uiso structure.