### PR TITLE
Fix off-center inversion for ObjCryst adapter

### DIFF
--- a/src/tests/TestObjCrystStructureAdapter.hpp
+++ b/src/tests/TestObjCrystStructureAdapter.hpp
@@ -247,6 +247,31 @@ class TestObjCrystStructureAdapter : public CxxTest::TestSuite
         }
 
 
+        void test_getEquivalentAtoms()
+        {
+            diffpy::mathutils::EpsilonEqual allclose;
+            auto_ptr<Crystal> crst(loadTestCrystal("NH4Br.cif"));
+            StructureAdapterPtr adpt = createStructureAdapter(*crst);
+            CrystalStructureAdapterPtr cadpt =
+                boost::dynamic_pointer_cast<CrystalStructureAdapter>(adpt);
+            TS_ASSERT_EQUALS(2, cadpt->countSites());
+            TS_ASSERT_EQUALS(4, cadpt->totalOccupancy());
+            CrystalStructureAdapter::AtomVector eq0, eq1;
+            eq0 = cadpt->getEquivalentAtoms(0);
+            TS_ASSERT_EQUALS(2, eq0.size());
+            cadpt->toFractional(eq0[0]);
+            cadpt->toFractional(eq0[1]);
+            TS_ASSERT(allclose(R3::Vector(0, 0.5, 0.03), eq0[0].xyz_cartn));
+            TS_ASSERT(allclose(R3::Vector(0.5, 0, 0.97), eq0[1].xyz_cartn));
+            eq1 = cadpt->getEquivalentAtoms(1);
+            TS_ASSERT_EQUALS(2, eq1.size());
+            cadpt->toFractional(eq1[0]);
+            cadpt->toFractional(eq1[1]);
+            TS_ASSERT(allclose(R3::Vector(0, 0, 0.5), eq1[0].xyz_cartn));
+            TS_ASSERT(allclose(R3::Vector(0.5, 0.5, 0.5), eq1[1].xyz_cartn));
+        }
+
+
         void test_serialization()
         {
             stringstream storage(ios::in | ios::out | ios::binary);

--- a/src/tests/testdata/NH4Br.cif
+++ b/src/tests/testdata/NH4Br.cif
@@ -1,0 +1,77 @@
+#------------------------------------------------------------------------------
+#$Date: 2017-10-06 19:24:22 +0300 (Fri, 06 Oct 2017) $
+#$Revision: 201816 $
+#$URL: file:///home/coder/svn-repositories/cod/cif/9/01/64/9016488.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/. The original data for this entry
+# were provided the American Mineralogist Crystal Structure Database,
+# http://rruff.geo.arizona.edu/AMS/amcsd.php
+#
+# The file may be used within the scientific community so long as
+# proper attribution is given to the journal article from which the
+# data were obtained.
+#
+data_9016488
+loop_
+_publ_author_name
+'Ketelaar, J.'
+_publ_section_title
+;
+ Crystal Structure of the Low Temperature Modification of Ammonium Bromide
+ _cod_database_code 1010540
+;
+_journal_name_full               Nature
+_journal_page_first              250
+_journal_page_last               251
+_journal_volume                  134
+_journal_year                    1934
+_chemical_formula_sum            'Br N'
+_space_group_IT_number           129
+_symmetry_space_group_name_Hall  'P 4ab 2ab -1ab'
+_symmetry_space_group_name_H-M   'P 4/n m m :1'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_length_a                   6.007
+_cell_length_b                   6.007
+_cell_length_c                   4.035
+_cell_volume                     145.599
+_database_code_amcsd             0017445
+_exptl_crystal_density_diffrn    2.142
+_cod_duplicate_entry             1010540
+_cod_original_sg_symbol_H-M      'P 4/n m m'
+_cod_database_code               9016488
+_amcsd_formula_title             'Br H4 N'
+loop_
+_space_group_symop_operation_xyz
+x,y,z
+1/2-y,1/2-x,z
+y,x,-z
+y,-x,-z
+1/2-y,1/2+x,z
+x,-y,z
+1/2-x,1/2+y,-z
+1/2+x,1/2+y,-z
+-x,-y,z
+1/2+y,1/2+x,z
+-y,-x,-z
+-y,x,-z
+1/2+y,1/2-x,z
+-x,y,z
+1/2+x,1/2-y,-z
+1/2-x,1/2-y,-z
+loop_
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_attached_hydrogens
+Br1 0.00000 0.50000 0.03000 0
+N1 0.00000 0.00000 0.50000 4
+loop_
+_cod_related_entry_id
+_cod_related_entry_database
+_cod_related_entry_code
+1 AMCSD 0017445


### PR DESCRIPTION
Fix incorrect unit cell expansion when inversion center is away from the origin.