### PR TITLE
PeakWidthModel serialization

### DIFF
--- a/src/diffpy/features.tpl
+++ b/src/diffpy/features.tpl
@@ -25,6 +25,9 @@
 # define DIFFPY_HAS_OBJCRYST
 #endif
 
+// FIXME -- temporary feature, remove when released
+#define DIFFPY_DEV_PEAKWIDTHMODEL_SERIALIZATION
+
 #endif  // FEATURES_HPP_INCLUDED
 
 // vim:ft=cpp:

--- a/src/diffpy/srreal/ConstantPeakWidth.cpp
+++ b/src/diffpy/srreal/ConstantPeakWidth.cpp
@@ -17,7 +17,7 @@
 *****************************************************************************/
 
 #include <diffpy/srreal/ConstantPeakWidth.hpp>
-#include <diffpy/serialization.hpp>
+#include <diffpy/serialization.ipp>
 
 namespace diffpy {
 namespace srreal {
@@ -87,5 +87,10 @@ bool reg_ConstantPeakWidth = ConstantPeakWidth().registerThisType();
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::ConstantPeakWidth)
+BOOST_CLASS_EXPORT_IMPLEMENT(diffpy::srreal::ConstantPeakWidth)
 
 // End of file

--- a/src/diffpy/srreal/ConstantPeakWidth.hpp
+++ b/src/diffpy/srreal/ConstantPeakWidth.hpp
@@ -48,10 +48,25 @@ class ConstantPeakWidth : public PeakWidthModel
 
         // data
         double mwidth;
-};
 
+        // serialization
+        friend class boost::serialization::access;
+
+        template<class Archive>
+            void serialize(Archive& ar, const unsigned int version)
+        {
+            using boost::serialization::base_object;
+            ar & base_object<PeakWidthModel>(*this);
+            ar & mwidth;
+        }
+
+};
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+BOOST_CLASS_EXPORT_KEY(diffpy::srreal::ConstantPeakWidth)
 
 #endif  // CONSTANTPEAKWIDTH_HPP_INCLUDED

--- a/src/diffpy/srreal/ConstantRadiiTable.cpp
+++ b/src/diffpy/srreal/ConstantRadiiTable.cpp
@@ -23,7 +23,6 @@
 #include <stdexcept>
 #include <vector>
 #include <boost/make_shared.hpp>
-#include <boost/serialization/export.hpp>
 
 #include <diffpy/serialization.ipp>
 #include <diffpy/srreal/ConstantRadiiTable.hpp>

--- a/src/diffpy/srreal/DebyeWallerPeakWidth.cpp
+++ b/src/diffpy/srreal/DebyeWallerPeakWidth.cpp
@@ -19,7 +19,7 @@
 
 #include <diffpy/srreal/DebyeWallerPeakWidth.hpp>
 #include <diffpy/srreal/StructureAdapter.hpp>
-#include <diffpy/serialization.hpp>
+#include <diffpy/serialization.ipp>
 
 namespace diffpy {
 namespace srreal {
@@ -74,5 +74,10 @@ bool reg_DebyeWallerPeakWidth = DebyeWallerPeakWidth().registerThisType();
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::DebyeWallerPeakWidth)
+BOOST_CLASS_EXPORT_IMPLEMENT(diffpy::srreal::DebyeWallerPeakWidth)
 
 // End of file

--- a/src/diffpy/srreal/DebyeWallerPeakWidth.hpp
+++ b/src/diffpy/srreal/DebyeWallerPeakWidth.hpp
@@ -39,10 +39,24 @@ class DebyeWallerPeakWidth : public PeakWidthModel
         virtual double calculate(const BaseBondGenerator&) const;
         virtual double maxWidth(StructureAdapterPtr,
                 double rmin, double rmax) const;
-};
 
+        // serialization
+        friend class boost::serialization::access;
+
+        template<class Archive>
+            void serialize(Archive& ar, const unsigned int version)
+        {
+            using boost::serialization::base_object;
+            ar & base_object<PeakWidthModel>(*this);
+        }
+
+};
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+BOOST_CLASS_EXPORT_KEY(diffpy::srreal::DebyeWallerPeakWidth)
 
 #endif  // DEBYEWALLERPEAKWIDTH_HPP_INCLUDED

--- a/src/diffpy/srreal/JeongPeakWidth.cpp
+++ b/src/diffpy/srreal/JeongPeakWidth.cpp
@@ -20,7 +20,7 @@
 
 #include <diffpy/srreal/JeongPeakWidth.hpp>
 #include <diffpy/mathutils.hpp>
-#include <diffpy/serialization.hpp>
+#include <diffpy/serialization.ipp>
 
 namespace diffpy {
 namespace srreal {
@@ -142,5 +142,10 @@ bool reg_JeongPeakWidth = JeongPeakWidth().registerThisType();
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::JeongPeakWidth)
+BOOST_CLASS_EXPORT_IMPLEMENT(diffpy::srreal::JeongPeakWidth)
 
 // End of file

--- a/src/diffpy/srreal/JeongPeakWidth.hpp
+++ b/src/diffpy/srreal/JeongPeakWidth.hpp
@@ -59,10 +59,28 @@ class JeongPeakWidth : public DebyeWallerPeakWidth
 
         // methods
         double msdSharpeningRatio(const double& r) const;
+
+        // serialization
+        friend class boost::serialization::access;
+
+        template<class Archive>
+            void serialize(Archive& ar, const unsigned int version)
+        {
+            using boost::serialization::base_object;
+            ar & base_object<DebyeWallerPeakWidth>(*this);
+            ar & mdelta1;
+            ar & mdelta2;
+            ar & mqbroad;
+        }
+
 };
 
 
 }   // namespace srreal
 }   // namespace diffpy
+
+// Serialization -------------------------------------------------------------
+
+BOOST_CLASS_EXPORT_KEY(diffpy::srreal::JeongPeakWidth)
 
 #endif  // JEONGPEAKWIDTH_HPP_INCLUDED

--- a/src/diffpy/srreal/PeakWidthModel.cpp
+++ b/src/diffpy/srreal/PeakWidthModel.cpp
@@ -16,8 +16,6 @@
 *
 *****************************************************************************/
 
-#include <boost/serialization/export.hpp>
-
 #include <diffpy/srreal/PeakWidthModel.hpp>
 #include <diffpy/HasClassRegistry.ipp>
 #include <diffpy/validators.hpp>
@@ -71,6 +69,9 @@ eventticker::EventTicker& PeakWidthModelOwner::ticker() const
 }   // namespace srreal
 }   // namespace diffpy
 
-DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::PeakWidthModelPtr)
+// Serialization -------------------------------------------------------------
+
+DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::PeakWidthModel)
+DIFFPY_INSTANTIATE_PTR_SERIALIZATION(diffpy::srreal::PeakWidthModel)
 
 // End of file

--- a/src/diffpy/srreal/PeakWidthModel.hpp
+++ b/src/diffpy/srreal/PeakWidthModel.hpp
@@ -26,8 +26,9 @@
 #define PEAKWIDTHMODEL_HPP_INCLUDED
 
 #include <boost/serialization/base_object.hpp>
-#include <boost/serialization/map.hpp>
-#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/assume_abstract.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/shared_ptr.hpp>
 
 #include <diffpy/Attributes.hpp>
 #include <diffpy/HasClassRegistry.hpp>
@@ -53,6 +54,16 @@ class PeakWidthModel :
 
         // data
         mutable eventticker::EventTicker mticker;
+
+    private:
+
+        // serialization
+        friend class boost::serialization::access;
+        template<class Archive>
+            void serialize(Archive& ar, const unsigned int version)
+        {
+            ar & mticker;
+        }
 
 };
 
@@ -93,51 +104,6 @@ class PeakWidthModelOwner
 
 // Serialization -------------------------------------------------------------
 
-namespace boost {
-namespace serialization {
-
-template<class Archive>
-void save(Archive& ar,
-        const diffpy::srreal::PeakWidthModelPtr& ptr,
-        const unsigned int version)
-{
-    using namespace diffpy::attributes;
-    std::string tp;
-    AttributesDataMap dt;
-    diffpy::eventticker::EventTicker tc;
-    if (ptr.get())
-    {
-        tp = ptr->type();
-        dt = saveAttributesData(*ptr);
-        tc = ptr->ticker();
-    }
-    ar & tp & dt & tc;
-}
-
-
-template<class Archive>
-void load(Archive& ar,
-        diffpy::srreal::PeakWidthModelPtr& ptr,
-        const unsigned int version)
-{
-    using namespace diffpy::attributes;
-    using namespace diffpy::srreal;
-    std::string tp;
-    AttributesDataMap dt;
-    diffpy::eventticker::EventTicker tc;
-    ar & tp & dt & tc;
-    if (!tp.empty())
-    {
-        ptr = PeakWidthModel::createByType(tp);
-        loadAttributesData(*ptr, dt);
-        ptr->ticker() = tc;
-    }
-    else  ptr.reset();
-}
-
-}   // namespace serialization
-}   // namespace boost
-
-BOOST_SERIALIZATION_SPLIT_FREE(diffpy::srreal::PeakWidthModelPtr)
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(diffpy::srreal::PeakWidthModel)
 
 #endif  // PEAKWIDTHMODEL_HPP_INCLUDED

--- a/src/tests/TestPeakWidthModel.hpp
+++ b/src/tests/TestPeakWidthModel.hpp
@@ -1,0 +1,132 @@
+/*****************************************************************************
+*
+* libdiffpy         Complex Modeling Initiative
+*                   (c) 2019 Brookhaven Science Associates,
+*                   Brookhaven National Laboratory.
+*                   All rights reserved.
+*
+* File coded by:    Pavol Juhas
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE.txt for license information.
+*
+******************************************************************************
+*
+* class TestPeakWidthModel -- test PeakWidthModel and derived classes
+*
+*****************************************************************************/
+
+#include <cxxtest/TestSuite.h>
+
+#include <diffpy/srreal/PeakWidthModel.hpp>
+#include <diffpy/srreal/DebyeWallerPeakWidth.hpp>
+#include <diffpy/srreal/JeongPeakWidth.hpp>
+#include <diffpy/srreal/AtomicStructureAdapter.hpp>
+#include "serialization_helpers.hpp"
+
+namespace diffpy {
+namespace srreal {
+
+const double tuiso = 0.004;
+
+//////////////////////////////////////////////////////////////////////////////
+// class TestPeakWidthModel
+//////////////////////////////////////////////////////////////////////////////
+
+class TestPeakWidthModel : public CxxTest::TestSuite
+{
+    private:
+
+        // data
+        PeakWidthModelPtr mdwpw;
+        PeakWidthModelPtr mjepw;
+        JeongPeakWidth* mcjepw;
+        double meps;
+
+        // methods
+        static AtomicStructureAdapterPtr dimer()
+        {
+            AtomicStructureAdapterPtr adpt(new AtomicStructureAdapter);
+            Atom a;
+            a.atomtype = "C";
+            a.uij_cartn = R3::identity() * tuiso;
+            adpt->append(a);
+            a.xyz_cartn[2] = 1;
+            adpt->append(a);
+            return adpt;
+        }
+
+    public:
+
+        void setUp()
+        {
+            mdwpw = PeakWidthModel::createByType("debye-waller");
+            mjepw = PeakWidthModel::createByType("jeong");
+            mcjepw = static_cast<JeongPeakWidth*>(mjepw.get());
+            meps = 10 * diffpy::mathutils::DOUBLE_EPS;
+        }
+
+
+        void test_clone()
+        {
+            TS_ASSERT_EQUALS(mdwpw->type(), mdwpw->clone()->type());
+            TS_ASSERT_EQUALS(mjepw->type(), mjepw->clone()->type());
+        }
+
+
+        void test_attributes()
+        {
+            TS_ASSERT_EQUALS(0, mdwpw->namesOfDoubleAttributes().size());
+            TS_ASSERT_EQUALS(3, mjepw->namesOfDoubleAttributes().size());
+            mcjepw->setDelta1(0.1);
+            mcjepw->setDelta2(0.2);
+            mcjepw->setQbroad(0.3);
+            TS_ASSERT_EQUALS(0.1, mjepw->getDoubleAttr("delta1"));
+            TS_ASSERT_EQUALS(0.2, mjepw->getDoubleAttr("delta2"));
+            TS_ASSERT_EQUALS(0.3, mjepw->getDoubleAttr("qbroad"));
+        }
+
+
+        void test_calculate()
+        {
+            using diffpy::mathutils::GAUSS_SIGMA_TO_FWHM;
+            AtomicStructureAdapterPtr adpt = dimer();
+            BaseBondGeneratorPtr bnds = adpt->createBondGenerator();
+            bnds->setRmax(2.0);
+            bnds->rewind();
+            const double w = GAUSS_SIGMA_TO_FWHM * sqrt(2 * tuiso);
+            TS_ASSERT_DELTA(w, mdwpw->calculate(*bnds), meps);
+            TS_ASSERT_DELTA(w, mjepw->calculate(*bnds), meps);
+            mcjepw->setDelta2(0.75);
+            TS_ASSERT_DELTA(0.5 * w, mjepw->calculate(*bnds), meps);
+            mcjepw->setDelta2(0);
+            mcjepw->setQbroad(sqrt(3));
+            TS_ASSERT_DELTA(2 * w, mjepw->calculate(*bnds), meps);
+        }
+
+
+        void test_serialization()
+        {
+            PeakWidthModelPtr pwm1 = dumpandload(mdwpw);
+            DebyeWallerPeakWidth* cpwm1 =
+                dynamic_cast<DebyeWallerPeakWidth*>(pwm1.get());
+            TS_ASSERT(cpwm1);
+            mcjepw->setDelta1(1.1);
+            mcjepw->setDoubleAttr("delta2", 2.2);
+            mcjepw->setDoubleAttr("qbroad", 0.03);
+            PeakWidthModelPtr pwm2 = dumpandload(mjepw);
+            JeongPeakWidth* cpwm2 = dynamic_cast<JeongPeakWidth*>(pwm2.get());
+            TS_ASSERT(cpwm2);
+            TS_ASSERT_EQUALS(1.1, pwm2->getDoubleAttr("delta1"));
+            TS_ASSERT_EQUALS(2.2, pwm2->getDoubleAttr("delta2"));
+            TS_ASSERT_EQUALS(0.03, pwm2->getDoubleAttr("qbroad"));
+        }
+
+};  // class TestPeakWidthModel
+
+}   // namespace srreal
+}   // namespace diffpy
+
+using diffpy::srreal::TestPeakWidthModel;
+
+// End of file


### PR DESCRIPTION
Convert PWM and derived classes to use explicit serialization.
Avoid restricting what internal data can be in derived classes.