### PR TITLE
ENH: add warning message when qmax > pi / rstep in PDFCalculator

### DIFF
--- a/src/diffpy/srreal/PDFCalculator.cpp
+++ b/src/diffpy/srreal/PDFCalculator.cpp
@@ -16,6 +16,7 @@
 *
 *****************************************************************************/
 
+#include <iostream>
 #include <stdexcept>
 #include <sstream>
 #include <cmath>
@@ -158,6 +159,7 @@ QuantityType PDFCalculator::getExtendedPDF() const
         !(1 < pdfutils_qminSteps(this));
     if (skipfft)
     {
+        cout << "WARNING: skip FFT because qmax > pi / rstep.";
         QuantityType rdfpr = this->getExtendedRDFperR();
         QuantityType rdfprb = this->applyBaseline(rgrid_ext, rdfpr);
         QuantityType pdf = this->applyEnvelopes(rgrid_ext, rdfprb);


### PR DESCRIPTION
@sbillinge I added the warning message. Refer to the this [issue](https://github.com/diffpy/diffpy.srreal/issues/24).