### PR TITLE
add conda lib to the build with boost

### DIFF
--- a/src/SConscript.configure
+++ b/src/SConscript.configure
@@ -46,6 +46,13 @@ conf = Configure(env, custom_tests={
     'CheckBoostVersion' : CheckBoostVersion,
     })
 
+# Add Conda include and library paths
+import os
+conda_prefix = Environment(ENV=os.environ)['ENV'].get('CONDA_PREFIX')
+if conda_prefix:
+    env.Append(CPPPATH=[os.path.join(conda_prefix, 'include')])
+    env.Append(LIBPATH=[os.path.join(conda_prefix, 'lib')])
+
 # serialization of unordered_map requires boost 1.56.0
 boost_required = '1.56.0'
 if not conf.CheckBoostVersion(boost_required):


### PR DESCRIPTION
This will add conda environment path when looking up boost. 

@sbillinge It wouldn't change any of the current behavior while making local installation possible. For some reason installing boost on `usr/local` can't be recognized, and now it can also search for boost installed in conda environment.