### PR TITLE
chore: update cpp minimum required version to c++23

### DIFF
--- a/site_scons/site_tools/cxxtest.py
+++ b/site_scons/site_tools/cxxtest.py
@@ -65,11 +65,11 @@
 
 from SCons.Script import *
 from SCons.Builder import Builder
-from SCons.Util import PrependPath, unique, uniquer
+from SCons.Util import PrependPath, unique, uniquer_hashables
 import os
 
 # A warning class to notify users of problems
-class ToolCxxTestWarning(SCons.Warnings.Warning):
+class ToolCxxTestWarning(SCons.Warnings.SConsWarning):
     pass
 
 SCons.Warnings.enableWarningClass(ToolCxxTestWarning)
@@ -105,7 +105,7 @@ def prepend_ld_library_path(env, overrides, **kwargs):
     """Prepend LD_LIBRARY_PATH with LIBPATH to run successfully programs that
     were linked against local shared libraries."""
     # make it unique but preserve order ...
-    libpath = uniquer(Split(kwargs.get('CXXTEST_LIBPATH', [])) +
+    libpath = uniquer_hashables(Split(kwargs.get('CXXTEST_LIBPATH', [])) +
                       Split(env.get(   'CXXTEST_LIBPATH', [])))
     if len(libpath) > 0:
         libpath = env.arg2nodes(libpath, env.fs.Dir)

--- a/src/SConscript
+++ b/src/SConscript
@@ -19,6 +19,10 @@ if env['tool'] == 'intelc':
 
 fast_linkflags = ['-s']
 
+# libobjcryst is built with double precision for ObjCryst's REAL type.
+# Match that ABI in all consumers of ObjCryst headers.
+env.PrependUnique(CPPDEFINES={'REAL': 'double'})
+
 # Specify minimum C++ standard.  Allow later standard from sconscript.local.
 # In case of multiple `-std` options the last option holds.
 env.PrependUnique(CXXFLAGS='-std=c++23', delete_existing=1)

--- a/src/SConscript
+++ b/src/SConscript
@@ -21,7 +21,7 @@ fast_linkflags = ['-s']
 
 # Specify minimum C++ standard.  Allow later standard from sconscript.local.
 # In case of multiple `-std` options the last option holds.
-env.PrependUnique(CXXFLAGS='-std=c++11', delete_existing=1)
+env.PrependUnique(CXXFLAGS='-std=c++23', delete_existing=1)
 
 # Platform specific intricacies.
 if env['PLATFORM'] == 'darwin':

--- a/src/diffpy/Attributes.hpp
+++ b/src/diffpy/Attributes.hpp
@@ -24,7 +24,7 @@
 #include <set>
 #include <map>
 #include <stdexcept>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace diffpy {
 namespace attributes {
@@ -109,7 +109,7 @@ class Attributes
 
         // types
         typedef std::map<std::string,
-                boost::shared_ptr<attributes::BaseDoubleAttribute> >
+                std::shared_ptr<attributes::BaseDoubleAttribute> >
                     DoubleAttributeStorage;
         // data
         DoubleAttributeStorage mdoubleattrs;

--- a/src/diffpy/HasClassRegistry.hpp
+++ b/src/diffpy/HasClassRegistry.hpp
@@ -32,7 +32,7 @@
 #include <stdexcept>
 #include <set>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace diffpy {
 
@@ -42,7 +42,7 @@ class HasClassRegistry
     public:
 
         // types
-        typedef boost::shared_ptr<TBase> SharedPtr;
+        typedef std::shared_ptr<TBase> SharedPtr;
 
         // Contains virtual methods
         virtual ~HasClassRegistry()  { }

--- a/src/diffpy/mathutils.hpp
+++ b/src/diffpy/mathutils.hpp
@@ -49,7 +49,7 @@ bool eps_lt(const double& x, const double& y, double eps=SQRT_DOUBLE_EPS);
 
 // binary functor for round-off aware less-than comparison
 
-class EpsilonLess : public std::binary_function<double, double, bool>
+class EpsilonLess
 {
     public:
 
@@ -77,7 +77,7 @@ class EpsilonLess : public std::binary_function<double, double, bool>
 
 // binary functor for round-off aware equality comparison
 
-class EpsilonEqual : public std::binary_function<double, double, bool>
+class EpsilonEqual
 {
     public:
 

--- a/src/diffpy/serialization.ipp
+++ b/src/diffpy/serialization.ipp
@@ -18,7 +18,7 @@
 *   diffpy::serialization_fromstring
 *
 * Definition of macros for explicit instantiation of serialization_tostring
-* and serialization_fromstring for type C or type boost::shared_ptr<C>.
+* and serialization_fromstring for type C or type std::shared_ptr<C>.
 *
 *   DIFFPY_INSTANTIATE_SERIALIZATION(C)
 *   DIFFPY_INSTANTIATE_PTR_SERIALIZATION(C)
@@ -29,7 +29,7 @@
 #define SERIALIZATION_IPP_INCLUDED
 
 #include <sstream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <diffpy/serialization.hpp>
 
 namespace diffpy {
@@ -70,9 +70,9 @@ void serialization_fromstring(T& tobj, const std::string& s)
         diffpy::serialization_fromstring<C>(C&, const std::string&); \
 
 /// Insert explicit instantiations for serialization_tostring and
-/// serialization_fromstring for type boost::shared_ptr<C>.
+/// serialization_fromstring for type std::shared_ptr<C>.
 
 #define DIFFPY_INSTANTIATE_PTR_SERIALIZATION(C) \
-    DIFFPY_INSTANTIATE_SERIALIZATION(boost::shared_ptr<C>)
+    DIFFPY_INSTANTIATE_SERIALIZATION(std::shared_ptr<C>)
 
 #endif  // SERIALIZATION_IPP_INCLUDED

--- a/src/diffpy/srreal/AtomicStructureAdapter.cpp
+++ b/src/diffpy/srreal/AtomicStructureAdapter.cpp
@@ -170,8 +170,8 @@ AtomicStructureAdapter::diff(StructureAdapterConstPtr other) const
     using std::min;
     StructureDifference sd = this->StructureAdapter::diff(other);
     if (sd.stru0 == sd.stru1)  return sd;
-    typedef boost::shared_ptr<const class AtomicStructureAdapter> APtr;
-    APtr pother = boost::dynamic_pointer_cast<APtr::element_type>(other);
+    typedef std::shared_ptr<const class AtomicStructureAdapter> APtr;
+    APtr pother = std::dynamic_pointer_cast<APtr::element_type>(other);
     if (!pother)  return sd;
     // try fast side-by-side comparison
     sd.diffmethod = StructureDifference::Method::SIDEBYSIDE;

--- a/src/diffpy/srreal/AtomicStructureAdapter.hpp
+++ b/src/diffpy/srreal/AtomicStructureAdapter.hpp
@@ -156,7 +156,7 @@ class AtomicStructureAdapter : public StructureAdapter
 
 };
 
-typedef boost::shared_ptr<AtomicStructureAdapter> AtomicStructureAdapterPtr;
+typedef std::shared_ptr<AtomicStructureAdapter> AtomicStructureAdapterPtr;
 
 // Complementary comparison function
 

--- a/src/diffpy/srreal/BVParametersTable.hpp
+++ b/src/diffpy/srreal/BVParametersTable.hpp
@@ -30,7 +30,7 @@
 namespace diffpy {
 namespace srreal {
 
-typedef boost::shared_ptr<class BVParametersTable> BVParametersTablePtr;
+typedef std::shared_ptr<class BVParametersTable> BVParametersTablePtr;
 
 class BVParametersTable
 {

--- a/src/diffpy/srreal/ConstantRadiiTable.cpp
+++ b/src/diffpy/srreal/ConstantRadiiTable.cpp
@@ -43,13 +43,13 @@ ConstantRadiiTable::ConstantRadiiTable() : mdefaultradius(0.0)
 
 AtomRadiiTablePtr ConstantRadiiTable::create() const
 {
-    return boost::make_shared<ConstantRadiiTable>();
+    return std::make_shared<ConstantRadiiTable>();
 }
 
 
 AtomRadiiTablePtr ConstantRadiiTable::clone() const
 {
-    return boost::make_shared<ConstantRadiiTable>(*this);
+    return std::make_shared<ConstantRadiiTable>(*this);
 }
 
 

--- a/src/diffpy/srreal/ConstantRadiiTable.cpp
+++ b/src/diffpy/srreal/ConstantRadiiTable.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <diffpy/serialization.ipp>
 #include <diffpy/srreal/ConstantRadiiTable.hpp>

--- a/src/diffpy/srreal/CrystalStructureAdapter.cpp
+++ b/src/diffpy/srreal/CrystalStructureAdapter.cpp
@@ -80,8 +80,8 @@ CrystalStructureAdapter::diff(StructureAdapterConstPtr other) const
 {
     StructureDifference sd = this->StructureAdapter::diff(other);
     if (sd.stru0 == sd.stru1)  return sd;
-    typedef boost::shared_ptr<const class CrystalStructureAdapter> CPtr;
-    CPtr cother = boost::dynamic_pointer_cast<CPtr::element_type>(other);
+    typedef std::shared_ptr<const class CrystalStructureAdapter> CPtr;
+    CPtr cother = std::dynamic_pointer_cast<CPtr::element_type>(other);
     if (!cother)  return sd;
     // compare symmetry operations in both adapters
     assert(cother == sd.stru1);

--- a/src/diffpy/srreal/CrystalStructureAdapter.hpp
+++ b/src/diffpy/srreal/CrystalStructureAdapter.hpp
@@ -129,7 +129,7 @@ class CrystalStructureAdapter : public PeriodicStructureAdapter
 };
 
 
-typedef boost::shared_ptr<CrystalStructureAdapter> CrystalStructureAdapterPtr;
+typedef std::shared_ptr<CrystalStructureAdapter> CrystalStructureAdapterPtr;
 
 // Comparison functions
 

--- a/src/diffpy/srreal/EmptyStructureAdapter.cpp
+++ b/src/diffpy/srreal/EmptyStructureAdapter.cpp
@@ -16,7 +16,7 @@
 *
 *****************************************************************************/
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <diffpy/serialization.ipp>
 #include <diffpy/srreal/StructureAdapter.hpp>

--- a/src/diffpy/srreal/EmptyStructureAdapter.cpp
+++ b/src/diffpy/srreal/EmptyStructureAdapter.cpp
@@ -45,14 +45,14 @@ class EmptyStructureAdapter : public StructureAdapter
         virtual StructureAdapterPtr clone() const
         {
             StructureAdapterPtr rv =
-                boost::const_pointer_cast<StructureAdapter>(shared_from_this());
+                std::const_pointer_cast<StructureAdapter>(shared_from_this());
             return rv;
         }
 
 
         virtual BaseBondGeneratorPtr createBondGenerator() const
         {
-            return boost::make_shared<BaseBondGenerator>(shared_from_this());
+            return std::make_shared<BaseBondGenerator>(shared_from_this());
         }
 
 

--- a/src/diffpy/srreal/NoMetaStructureAdapter.cpp
+++ b/src/diffpy/srreal/NoMetaStructureAdapter.cpp
@@ -38,8 +38,8 @@ namespace srreal {
 NoMetaStructureAdapter::NoMetaStructureAdapter(
         StructureAdapterPtr srcstructure)
 {
-    boost::shared_ptr<NoMetaStructureAdapter> nmptr =
-        boost::dynamic_pointer_cast<NoMetaStructureAdapter>(srcstructure);
+    std::shared_ptr<NoMetaStructureAdapter> nmptr =
+        std::dynamic_pointer_cast<NoMetaStructureAdapter>(srcstructure);
     if (nmptr)  srcstructure = nmptr->getSourceStructure();
     msrcstructure = srcstructure.get() ?
         srcstructure : emptyStructureAdapter();
@@ -49,7 +49,7 @@ NoMetaStructureAdapter::NoMetaStructureAdapter(
 
 StructureAdapterPtr NoMetaStructureAdapter::clone() const
 {
-    boost::shared_ptr<NoMetaStructureAdapter> rv(new NoMetaStructureAdapter);
+    std::shared_ptr<NoMetaStructureAdapter> rv(new NoMetaStructureAdapter);
     if (msrcstructure)  rv->msrcstructure = msrcstructure->clone();
     return rv;
 }
@@ -122,8 +122,8 @@ NoMetaStructureAdapter::diff(StructureAdapterConstPtr other) const
 {
     StructureDifference sd = this->StructureAdapter::diff(other);
     if (sd.stru0 == sd.stru1)  return sd;
-    typedef boost::shared_ptr<const class NoMetaStructureAdapter> PPtr;
-    PPtr pother = boost::dynamic_pointer_cast<PPtr::element_type>(other);
+    typedef std::shared_ptr<const class NoMetaStructureAdapter> PPtr;
+    PPtr pother = std::dynamic_pointer_cast<PPtr::element_type>(other);
     if (!pother)  return sd;
     sd = this->getSourceStructure()->diff(pother->getSourceStructure());
     assert(sd.stru0 == this->getSourceStructure());
@@ -152,7 +152,7 @@ NoMetaStructureAdapter::getSourceStructure() const
 StructureAdapterPtr nometa(StructureAdapterPtr stru)
 {
     StructureAdapterPtr rv =
-        boost::dynamic_pointer_cast<NoMetaStructureAdapter>(stru) ? stru :
+        std::dynamic_pointer_cast<NoMetaStructureAdapter>(stru) ? stru :
         StructureAdapterPtr(new NoMetaStructureAdapter(stru));
     return rv;
 }

--- a/src/diffpy/srreal/NoSymmetryStructureAdapter.cpp
+++ b/src/diffpy/srreal/NoSymmetryStructureAdapter.cpp
@@ -40,8 +40,8 @@ namespace srreal {
 NoSymmetryStructureAdapter::NoSymmetryStructureAdapter(
         StructureAdapterPtr srcstructure)
 {
-    boost::shared_ptr<NoSymmetryStructureAdapter> nmptr =
-        boost::dynamic_pointer_cast<NoSymmetryStructureAdapter>(srcstructure);
+    std::shared_ptr<NoSymmetryStructureAdapter> nmptr =
+        std::dynamic_pointer_cast<NoSymmetryStructureAdapter>(srcstructure);
     if (nmptr)  srcstructure = nmptr->getSourceStructure();
     msrcstructure = srcstructure.get() ?
         srcstructure : emptyStructureAdapter();
@@ -51,7 +51,7 @@ NoSymmetryStructureAdapter::NoSymmetryStructureAdapter(
 
 StructureAdapterPtr NoSymmetryStructureAdapter::clone() const
 {
-    boost::shared_ptr<NoSymmetryStructureAdapter>
+    std::shared_ptr<NoSymmetryStructureAdapter>
         rv(new NoSymmetryStructureAdapter);
     if (msrcstructure)  rv->msrcstructure = msrcstructure->clone();
     return rv;
@@ -119,8 +119,8 @@ NoSymmetryStructureAdapter::diff(StructureAdapterConstPtr other) const
 {
     StructureDifference sd = this->StructureAdapter::diff(other);
     if (sd.stru0 == sd.stru1)  return sd;
-    typedef boost::shared_ptr<const class NoSymmetryStructureAdapter> PPtr;
-    PPtr pother = boost::dynamic_pointer_cast<PPtr::element_type>(other);
+    typedef std::shared_ptr<const class NoSymmetryStructureAdapter> PPtr;
+    PPtr pother = std::dynamic_pointer_cast<PPtr::element_type>(other);
     if (!pother)  return sd;
     sd = this->getSourceStructure()->diff(pother->getSourceStructure());
     assert(sd.stru0 == this->getSourceStructure());
@@ -149,7 +149,7 @@ NoSymmetryStructureAdapter::getSourceStructure() const
 StructureAdapterPtr nosymmetry(StructureAdapterPtr stru)
 {
     StructureAdapterPtr rv =
-        boost::dynamic_pointer_cast<NoSymmetryStructureAdapter>(stru) ? stru :
+        std::dynamic_pointer_cast<NoSymmetryStructureAdapter>(stru) ? stru :
         StructureAdapterPtr(new NoSymmetryStructureAdapter(stru));
     return rv;
 }

--- a/src/diffpy/srreal/ObjCrystStructureAdapter.cpp
+++ b/src/diffpy/srreal/ObjCrystStructureAdapter.cpp
@@ -86,7 +86,7 @@ fetchSymmetryOperations(const ObjCryst::SpaceGroup& spacegroup)
     assert(nbtran * last <= nbsym);
     for (int nt = 0; nt < nbtran; ++nt)
     {
-        const float* pt = sgtrans[nt].tr;
+        const REAL* pt = sgtrans[nt].tr;
         R3::Vector sgt(pt[0], pt[1], pt[2]);
         for (int i = 0; i < last; ++i)
         {

--- a/src/diffpy/srreal/OverlapCalculator.cpp
+++ b/src/diffpy/srreal/OverlapCalculator.cpp
@@ -314,7 +314,7 @@ vector< unordered_set<int> > OverlapCalculator::neighborhoods() const
 {
     int cntsites = this->countSites();
     typedef unordered_set<int> SiteSet;
-    typedef std::vector< boost::shared_ptr<SiteSet> > SiteSetPointers;
+    typedef std::vector< std::shared_ptr<SiteSet> > SiteSetPointers;
     SiteSetPointers rvptr(cntsites);
     int n = this->count();
     for (int index = 0; index < n; ++index)

--- a/src/diffpy/srreal/PQEvaluator.hpp
+++ b/src/diffpy/srreal/PQEvaluator.hpp
@@ -24,7 +24,7 @@
 #ifndef PQEVALUATOR_HPP_INCLUDED
 #define PQEVALUATOR_HPP_INCLUDED
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/assume_abstract.hpp>
 #include <boost/serialization/export.hpp>
@@ -40,7 +40,7 @@ class PairQuantity;
 
 /// shared pointer to PQEvaluatorBasic
 
-typedef boost::shared_ptr<class PQEvaluatorBasic> PQEvaluatorPtr;
+typedef std::shared_ptr<class PQEvaluatorBasic> PQEvaluatorPtr;
 
 enum PQEvaluatorType {NONE, BASIC, OPTIMIZED, CHECK};
 

--- a/src/diffpy/srreal/PairQuantity.cpp
+++ b/src/diffpy/srreal/PairQuantity.cpp
@@ -150,7 +150,7 @@ void PairQuantity::setEvaluatorType(PQEvaluatorType evtp)
     {
         pqev->validate(*this);
     }
-    catch (logic_error e)
+    catch (const logic_error& e)
     {
         string emsg("EvaluatorType not supported.  ");
         emsg += e.what();

--- a/src/diffpy/srreal/PeriodicStructureAdapter.cpp
+++ b/src/diffpy/srreal/PeriodicStructureAdapter.cpp
@@ -65,8 +65,8 @@ PeriodicStructureAdapter::diff(StructureAdapterConstPtr other) const
 {
     StructureDifference sd = this->StructureAdapter::diff(other);
     if (sd.stru0 == sd.stru1)  return sd;
-    typedef boost::shared_ptr<const class PeriodicStructureAdapter> PPtr;
-    PPtr pother = boost::dynamic_pointer_cast<PPtr::element_type>(other);
+    typedef std::shared_ptr<const class PeriodicStructureAdapter> PPtr;
+    PPtr pother = std::dynamic_pointer_cast<PPtr::element_type>(other);
     if (!pother)  return sd;
     assert(pother == sd.stru1);
     if (this->getLattice() != pother->getLattice())  return sd;

--- a/src/diffpy/srreal/PeriodicStructureAdapter.hpp
+++ b/src/diffpy/srreal/PeriodicStructureAdapter.hpp
@@ -64,7 +64,7 @@ class PeriodicStructureAdapter : public AtomicStructureAdapter
 
 };
 
-typedef boost::shared_ptr<PeriodicStructureAdapter> PeriodicStructureAdapterPtr;
+typedef std::shared_ptr<PeriodicStructureAdapter> PeriodicStructureAdapterPtr;
 
 // Comparison functions
 

--- a/src/diffpy/srreal/StructureAdapter.hpp
+++ b/src/diffpy/srreal/StructureAdapter.hpp
@@ -22,7 +22,6 @@
 
 #include <vector>
 #include <memory>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/assume_abstract.hpp>
 #include <boost/serialization/export.hpp>

--- a/src/diffpy/srreal/StructureAdapter.hpp
+++ b/src/diffpy/srreal/StructureAdapter.hpp
@@ -21,7 +21,7 @@
 #define STRUCTUREADAPTER_HPP_INCLUDED
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/assume_abstract.hpp>
@@ -44,7 +44,7 @@ class StructureDifference;
 /// PairQuantity calculator
 
 class StructureAdapter :
-    public boost::enable_shared_from_this<StructureAdapter>
+    public std::enable_shared_from_this<StructureAdapter>
 {
     public:
 
@@ -160,10 +160,10 @@ StructureAdapterPtr convertToStructureAdapter(const T& stru)
 
 
 template <class T>
-StructureAdapterPtr convertToStructureAdapter(const boost::shared_ptr<T>& stru)
+StructureAdapterPtr convertToStructureAdapter(const std::shared_ptr<T>& stru)
 {
     StructureAdapterPtr rv =
-        boost::dynamic_pointer_cast<StructureAdapterPtr::element_type>(stru);
+        std::dynamic_pointer_cast<StructureAdapterPtr::element_type>(stru);
     assert(rv);
     return rv;
 }
@@ -173,7 +173,7 @@ inline
 StructureAdapterPtr convertToStructureAdapter(StructureAdapterConstPtr stru)
 {
     StructureAdapterPtr rv =
-        boost::const_pointer_cast<StructureAdapterPtr::element_type>(stru);
+        std::const_pointer_cast<StructureAdapterPtr::element_type>(stru);
     return rv;
 }
 

--- a/src/diffpy/srreal/forwardtypes.hpp
+++ b/src/diffpy/srreal/forwardtypes.hpp
@@ -20,15 +20,15 @@
 #define FORWARDTYPES_HPP_INCLUDED
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace diffpy {
 namespace srreal {
 
 /// shared pointers to structure adapter and bond generator related objects
-typedef boost::shared_ptr<class BaseBondGenerator> BaseBondGeneratorPtr;
-typedef boost::shared_ptr<class StructureAdapter> StructureAdapterPtr;
-typedef boost::shared_ptr<const class StructureAdapter> StructureAdapterConstPtr;
+typedef std::shared_ptr<class BaseBondGenerator> BaseBondGeneratorPtr;
+typedef std::shared_ptr<class StructureAdapter> StructureAdapterPtr;
+typedef std::shared_ptr<const class StructureAdapter> StructureAdapterConstPtr;
 
 /// type for holding indices for atom sites
 typedef std::vector<int> SiteIndices;

--- a/src/diffpy/srreal/scatteringfactordata.cpp
+++ b/src/diffpy/srreal/scatteringfactordata.cpp
@@ -100,8 +100,7 @@ class WaasKirfFormula
 };
 
 
-class wksmbl_equal :
-    public binary_function<WaasKirfFormula,WaasKirfFormula,bool>
+class wksmbl_equal
 {
     public:
         bool operator() (

--- a/src/tests/TestAtomicStructureAdapter.hpp
+++ b/src/tests/TestAtomicStructureAdapter.hpp
@@ -47,7 +47,7 @@ class TestAtomicStructureAdapter : public CxxTest::TestSuite
         {
             mstru = StructureAdapterPtr(new AtomicStructureAdapter);
             mpstru =
-                boost::dynamic_pointer_cast<AtomicStructureAdapter>(mstru);
+                std::dynamic_pointer_cast<AtomicStructureAdapter>(mstru);
         }
 
 
@@ -73,7 +73,7 @@ class TestAtomicStructureAdapter : public CxxTest::TestSuite
                 mpstru->append(ai);
             }
             AtomicStructureAdapterPtr cpstru =
-                boost::make_shared<AtomicStructureAdapter>(*mpstru);
+                std::make_shared<AtomicStructureAdapter>(*mpstru);
             sd = mstru->diff(mstru);
             TS_ASSERT(sd.allowsfastupdate())
             sd = mstru->diff(cpstru);
@@ -122,7 +122,7 @@ class TestAtomicStructureAdapter : public CxxTest::TestSuite
             StructureAdapterPtr stru1;
             stru1 = dumpandload(mstru);
             AtomicStructureAdapterPtr astru1 =
-                boost::dynamic_pointer_cast<AtomicStructureAdapter>(stru1);
+                std::dynamic_pointer_cast<AtomicStructureAdapter>(stru1);
             TS_ASSERT_EQUALS(2, astru1->countSites());
             TS_ASSERT_EQUALS((*mpstru)[0], (*astru1)[0]);
             TS_ASSERT_EQUALS((*mpstru)[1], (*astru1)[1]);
@@ -140,7 +140,7 @@ class TestAtomicStructureAdapter : public CxxTest::TestSuite
                 mpstru->append(ai);
             }
             AtomicStructureAdapterPtr cpstru =
-                boost::make_shared<AtomicStructureAdapter>(*mpstru);
+                std::make_shared<AtomicStructureAdapter>(*mpstru);
             TS_ASSERT_EQUALS(*mpstru, *cpstru);
             TS_ASSERT(!(*mpstru != *cpstru));
             cpstru->at(0).atomtype = "H";

--- a/src/tests/TestAtomicStructureAdapter.hpp
+++ b/src/tests/TestAtomicStructureAdapter.hpp
@@ -19,7 +19,7 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <diffpy/srreal/AtomicStructureAdapter.hpp>
 #include <diffpy/srreal/StructureDifference.hpp>

--- a/src/tests/TestBVSCalculator.hpp
+++ b/src/tests/TestBVSCalculator.hpp
@@ -39,7 +39,7 @@ class TestBVSCalculator : public CxxTest::TestSuite
     private:
 
         StructureAdapterPtr mnacl;
-        boost::shared_ptr<BVSCalculator> mbvc;
+        std::shared_ptr<BVSCalculator> mbvc;
 
     public:
 
@@ -92,7 +92,7 @@ class TestBVSCalculator : public CxxTest::TestSuite
             TS_ASSERT_EQUALS(0.0, mbvc->value()[4]);
             // create structure with bare atom symbols "Na", "Cl".
             PeriodicStructureAdapterPtr naclbare =
-                boost::dynamic_pointer_cast<
+                std::dynamic_pointer_cast<
                 PeriodicStructureAdapter>(mnacl->clone());
             for (int i = 0; i < naclbare->countSites(); ++i)
             {
@@ -147,7 +147,7 @@ class TestBVSCalculator : public CxxTest::TestSuite
             diffpy::serialization::oarchive oa(storage, ios::binary);
             oa << mbvc;
             diffpy::serialization::iarchive ia(storage, ios::binary);
-            boost::shared_ptr<BVSCalculator> bvc1;
+            std::shared_ptr<BVSCalculator> bvc1;
             TS_ASSERT(!bvc1.get());
             ia >> bvc1;
             TS_ASSERT_DIFFERS(mbvc.get(), bvc1.get());

--- a/src/tests/TestDebyePDFCalculator.hpp
+++ b/src/tests/TestDebyePDFCalculator.hpp
@@ -34,7 +34,7 @@ class TestDebyePDFCalculator : public CxxTest::TestSuite
 {
     private:
 
-        boost::shared_ptr<DebyePDFCalculator> mpdfc;
+        std::shared_ptr<DebyePDFCalculator> mpdfc;
         AtomicStructureAdapterPtr memptystru;
         AtomicStructureAdapterPtr mstru10;
         AtomicStructureAdapterPtr mstru10d1;
@@ -50,8 +50,8 @@ class TestDebyePDFCalculator : public CxxTest::TestSuite
             const int SZ = 10;
             meps = diffpy::mathutils::SQRT_DOUBLE_EPS;
             mpdfc.reset(new DebyePDFCalculator);
-            memptystru = boost::make_shared<AtomicStructureAdapter>();
-            mstru10 = boost::make_shared<AtomicStructureAdapter>();
+            memptystru = std::make_shared<AtomicStructureAdapter>();
+            mstru10 = std::make_shared<AtomicStructureAdapter>();
             Atom ai;
             ai.atomtype = "C";
             ai.uij_cartn = R3::identity();
@@ -62,11 +62,11 @@ class TestDebyePDFCalculator : public CxxTest::TestSuite
                 ai.xyz_cartn[0] = i;
                 mstru10->append(ai);
             }
-            mstru10d1 = boost::make_shared<AtomicStructureAdapter>(*mstru10);
+            mstru10d1 = std::make_shared<AtomicStructureAdapter>(*mstru10);
             (*mstru10d1)[0].atomtype = "Au";
-            mstru10r = boost::make_shared<AtomicStructureAdapter>();
+            mstru10r = std::make_shared<AtomicStructureAdapter>();
             mstru10r->assign(mstru10->rbegin(), mstru10->rend());
-            mstru9 = boost::make_shared<AtomicStructureAdapter>(*mstru10);
+            mstru9 = std::make_shared<AtomicStructureAdapter>(*mstru10);
             mstru9->erase(9);
         }
 
@@ -200,7 +200,7 @@ class TestDebyePDFCalculator : public CxxTest::TestSuite
             diffpy::serialization::oarchive oa(storage, ios::binary);
             oa << mpdfc;
             diffpy::serialization::iarchive ia(storage, ios::binary);
-            boost::shared_ptr<DebyePDFCalculator> pdfc1;
+            std::shared_ptr<DebyePDFCalculator> pdfc1;
             ia >> pdfc1;
             TS_ASSERT_DIFFERS(pdfc1.get(), mpdfc.get());
             TS_ASSERT_EQUALS(string("constant"),

--- a/src/tests/TestDebyePDFCalculator.hpp
+++ b/src/tests/TestDebyePDFCalculator.hpp
@@ -18,7 +18,7 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <diffpy/srreal/AtomicStructureAdapter.hpp>
 #include <diffpy/srreal/DebyePDFCalculator.hpp>

--- a/src/tests/TestEmptyStructureAdapter.hpp
+++ b/src/tests/TestEmptyStructureAdapter.hpp
@@ -65,7 +65,7 @@ class TestEmptyStructureAdapter : public CxxTest::TestSuite
             StructureAdapterPtr stru1;
             stru1 = dumpandload(mstru);
             AtomicStructureAdapterPtr astru1 =
-                boost::dynamic_pointer_cast<AtomicStructureAdapter>(stru1);
+                std::dynamic_pointer_cast<AtomicStructureAdapter>(stru1);
             TS_ASSERT(!astru1);
             TS_ASSERT_EQUALS(0, stru1->countSites());
             TS_ASSERT_EQUALS(stru1, stru1->clone());

--- a/src/tests/TestNoMetaStructureAdapter.hpp
+++ b/src/tests/TestNoMetaStructureAdapter.hpp
@@ -28,7 +28,6 @@
 #include "test_custompqconfig.hpp"
 
 using namespace std;
-using namespace boost;
 using namespace diffpy::srreal;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/tests/TestObjCrystStructureAdapter.hpp
+++ b/src/tests/TestObjCrystStructureAdapter.hpp
@@ -213,10 +213,10 @@ class TestObjCrystStructureAdapter : public CxxTest::TestSuite
         {
             StructureAdapterPtr acto = m_catio3;
             CrystalStructureAdapterPtr ccto(
-                boost::dynamic_pointer_cast<CrystalStructureAdapter>(acto));
+                std::dynamic_pointer_cast<CrystalStructureAdapter>(acto));
             StructureAdapterPtr acto2 = acto->clone();
             CrystalStructureAdapterPtr ccto2(
-                boost::dynamic_pointer_cast<CrystalStructureAdapter>(acto2));
+                std::dynamic_pointer_cast<CrystalStructureAdapter>(acto2));
             TS_ASSERT_EQUALS(0.0, diffdegree(acto, acto));
             TS_ASSERT_EQUALS(1.0, diffdegree(acto, StructureAdapterPtr()));
             TS_ASSERT_EQUALS(0.0, diffdegree(acto, acto2));
@@ -253,7 +253,7 @@ class TestObjCrystStructureAdapter : public CxxTest::TestSuite
             unique_ptr<Crystal> crst(loadTestCrystal("NH4Br.cif"));
             StructureAdapterPtr adpt = createStructureAdapter(*crst);
             CrystalStructureAdapterPtr cadpt =
-                boost::dynamic_pointer_cast<CrystalStructureAdapter>(adpt);
+                std::dynamic_pointer_cast<CrystalStructureAdapter>(adpt);
             TS_ASSERT_EQUALS(2, cadpt->countSites());
             TS_ASSERT_EQUALS(4, cadpt->totalOccupancy());
             CrystalStructureAdapter::AtomVector eq0, eq1;

--- a/src/tests/TestOverlapCalculator.hpp
+++ b/src/tests/TestOverlapCalculator.hpp
@@ -35,7 +35,7 @@ class TestOverlapCalculator : public CxxTest::TestSuite
 {
     private:
 
-        boost::shared_ptr<OverlapCalculator> molc;
+        std::shared_ptr<OverlapCalculator> molc;
         StructureAdapterPtr mnacl;
         double meps;
 
@@ -347,7 +347,7 @@ class TestOverlapCalculator : public CxxTest::TestSuite
             stru->append(a0);
             stru->append(a1);
             molc->eval(stru);
-            boost::shared_ptr<OverlapCalculator> olc1;
+            std::shared_ptr<OverlapCalculator> olc1;
             olc1 = dumpandload(molc);
             TS_ASSERT_DIFFERS(molc.get(), olc1.get());
             TS_ASSERT_EQUALS(2, olc1->getStructure()->countSites());

--- a/src/tests/TestOverlapCalculator.hpp
+++ b/src/tests/TestOverlapCalculator.hpp
@@ -156,7 +156,6 @@ class TestOverlapCalculator : public CxxTest::TestSuite
 
         void test_bccTouch()
         {
-            using namespace boost;
             PeriodicStructureAdapterPtr bcc(new PeriodicStructureAdapter);
             bcc->setLatPar(2.0, 2.0, 2.0, 90, 90, 90);
             Atom a;
@@ -226,7 +225,6 @@ class TestOverlapCalculator : public CxxTest::TestSuite
 
         void test_NaCl_gradient()
         {
-            using namespace boost;
             molc->eval(mnacl);
             // default gradients are all zero
             std::vector<R3::Vector> g = molc->gradients();

--- a/src/tests/TestPDFCalculator.hpp
+++ b/src/tests/TestPDFCalculator.hpp
@@ -33,7 +33,7 @@ class TestPDFCalculator : public CxxTest::TestSuite
 {
     private:
 
-        boost::shared_ptr<PDFCalculator> mpdfc;
+        std::shared_ptr<PDFCalculator> mpdfc;
         StructureAdapterPtr memptystru;
         double meps;
         double mepsdb;
@@ -265,7 +265,7 @@ class TestPDFCalculator : public CxxTest::TestSuite
             diffpy::serialization::oarchive oa(storage, ios::binary);
             oa << mpdfc;
             diffpy::serialization::iarchive ia(storage, ios::binary);
-            boost::shared_ptr<PDFCalculator> pdfc1;
+            std::shared_ptr<PDFCalculator> pdfc1;
             ia >> pdfc1;
             TS_ASSERT_DIFFERS(pdfc1.get(), mpdfc.get());
             TS_ASSERT_EQUALS(string("constant"),

--- a/src/tests/TestPQEvaluator.hpp
+++ b/src/tests/TestPQEvaluator.hpp
@@ -89,7 +89,7 @@ class TestPQEvaluator : public CxxTest::TestSuite
             mzeros.assign(mpdfcb.getRgrid().size(), 0.0);
             // setup structure instances
             const int SZ = 10;
-            mstru10 = boost::make_shared<AtomicStructureAdapter>();
+            mstru10 = std::make_shared<AtomicStructureAdapter>();
             Atom ai;
             ai.atomtype = "C";
             ai.uij_cartn = R3::identity();
@@ -100,11 +100,11 @@ class TestPQEvaluator : public CxxTest::TestSuite
                 ai.xyz_cartn[0] = i;
                 mstru10->append(ai);
             }
-            mstru10d1 = boost::make_shared<AtomicStructureAdapter>(*mstru10);
+            mstru10d1 = std::make_shared<AtomicStructureAdapter>(*mstru10);
             (*mstru10d1)[0].atomtype = "Au";
-            mstru10r = boost::make_shared<AtomicStructureAdapter>();
+            mstru10r = std::make_shared<AtomicStructureAdapter>();
             mstru10r->assign(mstru10->rbegin(), mstru10->rend());
-            mstru9 = boost::make_shared<AtomicStructureAdapter>(*mstru10);
+            mstru9 = std::make_shared<AtomicStructureAdapter>(*mstru10);
             mstru9->erase(9);
         }
 
@@ -176,7 +176,7 @@ class TestPQEvaluator : public CxxTest::TestSuite
             mpdfcb.setTypeMask("O2-", "all", false);
             mpdfco.setTypeMask("O2-", "all", false);
             PeriodicStructureAdapterPtr litao =
-                boost::dynamic_pointer_cast<PeriodicStructureAdapter>(
+                std::dynamic_pointer_cast<PeriodicStructureAdapter>(
                         loadTestPeriodicStructure("LiTaO3.stru"));
             TS_ASSERT_EQUALS(mzeros, this->pdfcdiff(litao));
             TS_ASSERT_EQUALS(BASIC, mpdfco.getEvaluatorTypeUsed());

--- a/src/tests/TestPQEvaluator.hpp
+++ b/src/tests/TestPQEvaluator.hpp
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <diffpy/srreal/PQEvaluator.hpp>
 #include <diffpy/srreal/AtomicStructureAdapter.hpp>

--- a/src/tests/TestPeriodicStructureAdapter.hpp
+++ b/src/tests/TestPeriodicStructureAdapter.hpp
@@ -196,7 +196,7 @@ class TestPeriodicStructureAdapter : public CxxTest::TestSuite
         void test_getLattice()
         {
             PeriodicStructureAdapterPtr pkbise =
-                boost::dynamic_pointer_cast<PeriodicStructureAdapter>(m_kbise);
+                std::dynamic_pointer_cast<PeriodicStructureAdapter>(m_kbise);
             TS_ASSERT(pkbise);
             const Lattice& L = pkbise->getLattice();
             const double eps = 1.0e-12;
@@ -222,9 +222,9 @@ class TestPeriodicStructureAdapter : public CxxTest::TestSuite
             TS_ASSERT_EQUALS(string("Se"), kbise1->siteAtomType(10));
             TS_ASSERT_EQUALS(string("Se"), kbise1->siteAtomType(22));
             PeriodicStructureAdapterPtr pkbise =
-                boost::dynamic_pointer_cast<PeriodicStructureAdapter>(m_kbise);
+                std::dynamic_pointer_cast<PeriodicStructureAdapter>(m_kbise);
             PeriodicStructureAdapterPtr pkbise1 =
-                boost::dynamic_pointer_cast<PeriodicStructureAdapter>(kbise1);
+                std::dynamic_pointer_cast<PeriodicStructureAdapter>(kbise1);
             const Lattice& L = pkbise->getLattice();
             const Lattice& L1 = pkbise1->getLattice();
             TS_ASSERT_EQUALS(L.a(), L1.a());

--- a/src/tests/test_custompqconfig.hpp
+++ b/src/tests/test_custompqconfig.hpp
@@ -70,7 +70,7 @@ BOOST_CLASS_EXPORT(PeriodicAdapterWithPQConfig)
 
 // Typedefs and Functions ----------------------------------------------------
 
-typedef boost::shared_ptr<PeriodicAdapterWithPQConfig>
+typedef std::shared_ptr<PeriodicAdapterWithPQConfig>
     PeriodicAdapterWithPQConfigPtr;
 
 inline
@@ -78,7 +78,7 @@ PeriodicAdapterWithPQConfigPtr
 addCustomPQConfig(StructureAdapterPtr stru)
 {
     PeriodicStructureAdapterPtr pstru =
-        boost::dynamic_pointer_cast<PeriodicStructureAdapter>(stru);
+        std::dynamic_pointer_cast<PeriodicStructureAdapter>(stru);
     return PeriodicAdapterWithPQConfigPtr(
             new PeriodicAdapterWithPQConfig(*pstru));
 }


### PR DESCRIPTION
This PR updates cpp language version to c++23 and replaces boost smart pointer usages with stl implementations.