### PR TITLE
ENH:Add 3D PDF calculator support

### DIFF
--- a/src/diffpy/srreal/ObjCrystStructureAdapter.cpp
+++ b/src/diffpy/srreal/ObjCrystStructureAdapter.cpp
@@ -86,7 +86,7 @@ fetchSymmetryOperations(const ObjCryst::SpaceGroup& spacegroup)
     assert(nbtran * last <= nbsym);
     for (int nt = 0; nt < nbtran; ++nt)
     {
-        const float* pt = sgtrans[nt].tr;
+        const double* pt = sgtrans[nt].tr;
         R3::Vector sgt(pt[0], pt[1], pt[2]);
         for (int i = 0; i < last; ++i)
         {

--- a/src/diffpy/srreal/PDF3DCalculator.cpp
+++ b/src/diffpy/srreal/PDF3DCalculator.cpp
@@ -1,0 +1,1308 @@
+/*************************************************************************************
+*
+* libdiffpy         by DANSE Diffraction group
+*                   Simon J. L. Billinge
+*                   (c) 2009 The Trustees of Columbia University
+*                   in the City of New York.  All rights reserved.
+*
+* File coded by:    Hai Qiao
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE_DANSE.txt for license information.
+*
+/*************************************************************************************
+*
+* class PDF3DCalculator -- Implementation of PDF3DCalculator
+*
+*************************************************************************************/
+
+#include <diffpy/srreal/PDF3DCalculator.hpp>
+#include <diffpy/srreal/BaseBondGenerator.hpp>
+#include <diffpy/srreal/StructureAdapter.hpp>
+#include <cmath>
+#include <algorithm>
+#include <stdexcept>
+#include <limits>
+#include <diffpy/serialization.hpp>
+#include <diffpy/srreal/R3linalg.hpp>
+#include <diffpy/srreal/PQEvaluator.hpp>
+#include <gsl/gsl_fft_complex.h>
+#include <fstream>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+using namespace std;
+
+namespace diffpy {
+namespace srreal {
+
+// Static constants
+constexpr double PDF3DCalculator::DEFAULT_RMAX_3D;
+constexpr double PDF3DCalculator::DEFAULT_GRID_STEP;
+
+// Constructor ---------------------------------------------------------------
+
+PDF3DCalculator::PDF3DCalculator() :
+    mdr(DEFAULT_GRID_STEP),
+    mnbins(0),
+    maccumblocksize(32),
+    mapplyrho0background3d(true),
+    musecqwindow3d(true),
+    mcalculationmode3d(0),
+    mhistogramweightmode3d(0),
+    menablennDelta3d(false),
+    mnnDelta3d(0.0),
+    mnnDelta3dUpperBound(0.0),
+    mnnDeltaPositiveEta3d(0.9),
+    mdistanceDelta1_3d(0.0),
+    mdistanceDelta2_3d(0.0),
+    mdeltaPairA3d("*"),
+    mdeltaPairB3d("*"),
+    mdeltaShellIndex3d(1),
+    mdeltaShellTolerance3d(0.05),
+    mdeltaKeyTolerance3d(1.0e-6),
+    museadpscaleSensitivity3d(false),
+    madpScale3d(1.0),
+    mrho0backgroundscale3d(1.0),
+    mtotaloccupancy(0.0),
+    msfaverage(0.0)
+{
+    this->registerDoubleAttribute("enable_nn_delta3d",
+            this,
+            &PDF3DCalculator::getEnableNNDelta3DAttr,
+            &PDF3DCalculator::setEnableNNDelta3DAttr);
+    this->registerDoubleAttribute("nn_delta3d",
+            this,
+            &PDF3DCalculator::getNNDelta3D,
+            &PDF3DCalculator::setNNDelta3D);
+    this->registerDoubleAttribute("nn_delta3d_upper_bound",
+            this,
+            &PDF3DCalculator::getNNDelta3DUpperBound);
+    this->registerDoubleAttribute("nn_delta_positive_eta3d",
+            this,
+            &PDF3DCalculator::getNNDeltaPositiveEta3D,
+            &PDF3DCalculator::setNNDeltaPositiveEta3D);
+    this->registerDoubleAttribute("delta1_3d",
+            this,
+            &PDF3DCalculator::getDistanceDelta1_3D,
+            &PDF3DCalculator::setDistanceDelta1_3D);
+    this->registerDoubleAttribute("delta2_3d",
+            this,
+            &PDF3DCalculator::getDistanceDelta2_3D,
+            &PDF3DCalculator::setDistanceDelta2_3D);
+    this->registerDoubleAttribute("delta_shell_index3d",
+            this,
+            &PDF3DCalculator::getDeltaShellIndex3DAttr,
+            &PDF3DCalculator::setDeltaShellIndex3DAttr);
+    this->registerDoubleAttribute("delta_shell_tolerance3d",
+            this,
+            &PDF3DCalculator::getDeltaShellTolerance3D,
+            &PDF3DCalculator::setDeltaShellTolerance3D);
+    this->registerDoubleAttribute("delta_key_tolerance3d",
+            this,
+            &PDF3DCalculator::getDeltaKeyTolerance3D,
+            &PDF3DCalculator::setDeltaKeyTolerance3D);
+    this->registerDoubleAttribute("use_adp_scale_sensitivity3d",
+            this,
+            &PDF3DCalculator::getUseADPScaleSensitivity3DAttr,
+            &PDF3DCalculator::setUseADPScaleSensitivity3DAttr);
+    this->registerDoubleAttribute("adp_scale3d",
+            this,
+            &PDF3DCalculator::getADPScale3D,
+            &PDF3DCalculator::setADPScale3D);
+    this->registerDoubleAttribute("rho0_background_scale3d",
+            this,
+            &PDF3DCalculator::getRho0BackgroundScale3D,
+            &PDF3DCalculator::setRho0BackgroundScale3D);
+    this->registerDoubleAttribute("calculation_mode3d",
+            this,
+            &PDF3DCalculator::getCalculationMode3DAttr,
+            &PDF3DCalculator::setCalculationMode3DAttr);
+    this->registerDoubleAttribute("histogram_weight_mode3d",
+            this,
+            &PDF3DCalculator::getHistogramWeightMode3DAttr,
+            &PDF3DCalculator::setHistogramWeightMode3DAttr);
+
+    this->setRmax(DEFAULT_RMAX_3D);
+    this->setRstep(mdr);
+    this->setQmax(12.0);
+}
+
+// Public Methods ------------------------------------------------------------
+
+void PDF3DCalculator::setGridStep(double dr)
+{
+    if (dr <= 0) throw std::invalid_argument("Grid step must be positive.");
+    if (dr != mdr)
+    {
+        mdr = dr;
+        this->setRstep(dr);
+        this->resetValue(); // triggers re-allocation
+    }
+}
+
+double PDF3DCalculator::getGridStep() const
+{
+    return mdr;
+}
+
+void PDF3DCalculator::setAccumBlockSize(int bs)
+{
+    if (bs <= 0) throw std::invalid_argument("Accumulation block size must be positive.");
+    maccumblocksize = bs;
+}
+
+int PDF3DCalculator::getAccumBlockSize() const
+{
+    return maccumblocksize;
+}
+
+void PDF3DCalculator::setApplyRho0Background3D(bool v)
+{
+    mapplyrho0background3d = v;
+}
+
+bool PDF3DCalculator::getApplyRho0Background3D() const
+{
+    return mapplyrho0background3d;
+}
+
+void PDF3DCalculator::setUseCQWindow3D(bool v)
+{
+    musecqwindow3d = v;
+}
+
+bool PDF3DCalculator::getUseCQWindow3D() const
+{
+    return musecqwindow3d;
+}
+
+void PDF3DCalculator::setCalculationMode3D(int mode)
+{
+    if (mode != 0 && mode != 1)
+        throw std::invalid_argument("3D calculation mode must be 0 (ADP PDF) or 1 (vector histogram).");
+    if (mcalculationmode3d != mode)  mticker.click();
+    mcalculationmode3d = mode;
+}
+
+int PDF3DCalculator::getCalculationMode3D() const
+{
+    return mcalculationmode3d;
+}
+
+double PDF3DCalculator::getCalculationMode3DAttr() const
+{
+    return static_cast<double>(mcalculationmode3d);
+}
+
+void PDF3DCalculator::setCalculationMode3DAttr(double v)
+{
+    const int mode = static_cast<int>(std::lround(v));
+    if (std::fabs(v - static_cast<double>(mode)) > 1.0e-8)
+        throw std::invalid_argument("3D calculation mode must be an integer value.");
+    this->setCalculationMode3D(mode);
+}
+
+void PDF3DCalculator::setHistogramWeightMode3D(int mode)
+{
+    if (mode != 0 && mode != 1)
+        throw std::invalid_argument("3D histogram weight mode must be 0 (scattering) or 1 (count).");
+    if (mhistogramweightmode3d != mode)  mticker.click();
+    mhistogramweightmode3d = mode;
+}
+
+int PDF3DCalculator::getHistogramWeightMode3D() const
+{
+    return mhistogramweightmode3d;
+}
+
+double PDF3DCalculator::getHistogramWeightMode3DAttr() const
+{
+    return static_cast<double>(mhistogramweightmode3d);
+}
+
+void PDF3DCalculator::setHistogramWeightMode3DAttr(double v)
+{
+    const int mode = static_cast<int>(std::lround(v));
+    if (std::fabs(v - static_cast<double>(mode)) > 1.0e-8)
+        throw std::invalid_argument("3D histogram weight mode must be an integer value.");
+    this->setHistogramWeightMode3D(mode);
+}
+
+void PDF3DCalculator::setEnableNNDelta3D(bool v)
+{
+    if (menablennDelta3d != v)  mticker.click();
+    menablennDelta3d = v;
+}
+
+bool PDF3DCalculator::getEnableNNDelta3D() const
+{
+    return menablennDelta3d;
+}
+
+double PDF3DCalculator::getEnableNNDelta3DAttr() const
+{
+    return menablennDelta3d ? 1.0 : 0.0;
+}
+
+void PDF3DCalculator::setEnableNNDelta3DAttr(double v)
+{
+    this->setEnableNNDelta3D(v != 0.0);
+}
+
+void PDF3DCalculator::setNNDelta3D(double v)
+{
+    if (v < 0.0) throw std::invalid_argument("3D NN delta must be non-negative.");
+    const double bound = this->currentNNDeltaUpperBound();
+    if (!mdeltaShellRecords.empty())
+    {
+        if (bound <= 0.0 && v > 0.0)
+            throw std::invalid_argument("3D NN delta cannot be positive without a positive-definite shell bound.");
+        if (bound > 0.0 && v >= bound)
+            throw std::invalid_argument("3D NN delta exceeds the positive-definite shell bound.");
+    }
+    if (mnnDelta3d != v)  mticker.click();
+    mnnDelta3d = v;
+}
+
+const double& PDF3DCalculator::getNNDelta3D() const
+{
+    return mnnDelta3d;
+}
+
+double PDF3DCalculator::getNNDelta3DUpperBound() const
+{
+    return this->currentNNDeltaUpperBound();
+}
+
+const double& PDF3DCalculator::getNNDeltaPositiveEta3D() const
+{
+    return mnnDeltaPositiveEta3d;
+}
+
+void PDF3DCalculator::setNNDeltaPositiveEta3D(double v)
+{
+    if (v <= 0.0 || v >= 1.0)
+        throw std::invalid_argument("Positive-definite eta must be between 0 and 1.");
+    const double minproj = (mnnDeltaPositiveEta3d > 0.0) ?
+        (mnnDelta3dUpperBound / mnnDeltaPositiveEta3d) : 0.0;
+    if (mnnDeltaPositiveEta3d != v)  mticker.click();
+    mnnDeltaPositiveEta3d = v;
+    if (minproj > 0.0)  mnnDelta3dUpperBound = mnnDeltaPositiveEta3d * minproj;
+    this->validateNNDelta3D();
+    this->validateDistanceDecayDelta3D();
+}
+
+void PDF3DCalculator::setDistanceDelta1_3D(double v)
+{
+    if (v < 0.0) throw std::invalid_argument("3D distance-delta delta1 must be non-negative.");
+    if (mdistanceDelta1_3d != v)  mticker.click();
+    mdistanceDelta1_3d = v;
+    this->validateDistanceDecayDelta3D();
+}
+
+const double& PDF3DCalculator::getDistanceDelta1_3D() const
+{
+    return mdistanceDelta1_3d;
+}
+
+void PDF3DCalculator::setDistanceDelta2_3D(double v)
+{
+    if (v < 0.0) throw std::invalid_argument("3D distance-delta delta2 must be non-negative.");
+    if (mdistanceDelta2_3d != v)  mticker.click();
+    mdistanceDelta2_3d = v;
+    this->validateDistanceDecayDelta3D();
+}
+
+const double& PDF3DCalculator::getDistanceDelta2_3D() const
+{
+    return mdistanceDelta2_3d;
+}
+
+void PDF3DCalculator::setDeltaPairTypes3D(const std::string& a, const std::string& b)
+{
+    if (a.empty() || b.empty())
+        throw std::invalid_argument("Delta pair atom types must be non-empty.");
+    if (mdeltaPairA3d != a || mdeltaPairB3d != b)  mticker.click();
+    mdeltaPairA3d = a;
+    mdeltaPairB3d = b;
+}
+
+const std::string& PDF3DCalculator::getDeltaPairA3D() const
+{
+    return mdeltaPairA3d;
+}
+
+const std::string& PDF3DCalculator::getDeltaPairB3D() const
+{
+    return mdeltaPairB3d;
+}
+
+void PDF3DCalculator::setDeltaShellIndex3D(int v)
+{
+    if (v <= 0) throw std::invalid_argument("Delta shell index must be positive.");
+    if (mdeltaShellIndex3d != v)  mticker.click();
+    mdeltaShellIndex3d = v;
+}
+
+int PDF3DCalculator::getDeltaShellIndex3D() const
+{
+    return mdeltaShellIndex3d;
+}
+
+double PDF3DCalculator::getDeltaShellIndex3DAttr() const
+{
+    return static_cast<double>(mdeltaShellIndex3d);
+}
+
+void PDF3DCalculator::setDeltaShellIndex3DAttr(double v)
+{
+    this->setDeltaShellIndex3D(static_cast<int>(std::floor(v + 0.5)));
+}
+
+const double& PDF3DCalculator::getDeltaShellTolerance3D() const
+{
+    return mdeltaShellTolerance3d;
+}
+
+void PDF3DCalculator::setDeltaShellTolerance3D(double v)
+{
+    if (v <= 0.0) throw std::invalid_argument("Delta shell tolerance must be positive.");
+    if (mdeltaShellTolerance3d != v)  mticker.click();
+    mdeltaShellTolerance3d = v;
+}
+
+const double& PDF3DCalculator::getDeltaKeyTolerance3D() const
+{
+    return mdeltaKeyTolerance3d;
+}
+
+void PDF3DCalculator::setDeltaKeyTolerance3D(double v)
+{
+    if (v <= 0.0) throw std::invalid_argument("Delta key tolerance must be positive.");
+    if (mdeltaKeyTolerance3d != v)  mticker.click();
+    mdeltaKeyTolerance3d = v;
+}
+
+int PDF3DCalculator::getDeltaEligiblePairCount3D() const
+{
+    return static_cast<int>(mdeltaEligibleBondKeys.size());
+}
+
+void PDF3DCalculator::setUseADPScaleSensitivity3D(bool v)
+{
+    if (museadpscaleSensitivity3d != v)  mticker.click();
+    museadpscaleSensitivity3d = v;
+    this->validateNNDelta3D();
+}
+
+bool PDF3DCalculator::getUseADPScaleSensitivity3D() const
+{
+    return museadpscaleSensitivity3d;
+}
+
+double PDF3DCalculator::getUseADPScaleSensitivity3DAttr() const
+{
+    return museadpscaleSensitivity3d ? 1.0 : 0.0;
+}
+
+void PDF3DCalculator::setUseADPScaleSensitivity3DAttr(double v)
+{
+    this->setUseADPScaleSensitivity3D(v != 0.0);
+}
+
+void PDF3DCalculator::setADPScale3D(double v)
+{
+    if (v <= 0.0) throw std::invalid_argument("3D ADP scale must be positive.");
+    if (madpScale3d != v)  mticker.click();
+    madpScale3d = v;
+    this->validateNNDelta3D();
+}
+
+const double& PDF3DCalculator::getADPScale3D() const
+{
+    return madpScale3d;
+}
+
+void PDF3DCalculator::setRho0BackgroundScale3D(double v)
+{
+    if (v < 0.0) throw std::invalid_argument("3D rho0 background scale must be non-negative.");
+    if (mrho0backgroundscale3d != v)  mticker.click();
+    mrho0backgroundscale3d = v;
+}
+
+const double& PDF3DCalculator::getRho0BackgroundScale3D() const
+{
+    return mrho0backgroundscale3d;
+}
+
+QuantityType PDF3DCalculator::get3DPDF() const
+{
+    QuantityType result;
+    std::vector<double> grid = mgrid3d;
+    if (!this->isVectorHistogramMode3D())
+    {
+        if (musecqwindow3d) applyQWindow3D(grid);
+
+        const double rdf_scale = (mtotaloccupancy * msfaverage == 0.0) ? 0.0 :
+            1.0 / (mtotaloccupancy * msfaverage * msfaverage);
+        if (rdf_scale != 1.0)
+        {
+            for (double& val : grid) val *= rdf_scale;
+        }
+
+        if (mapplyrho0background3d)
+        {
+            const double rho0_bg = computeRho0Background();
+            if (rho0_bg != 0.0)
+            {
+                for (double& val : grid) val -= rho0_bg;
+            }
+        }
+
+        double qdamp = 0.0;
+        try
+        {
+            qdamp = this->getEnvelopeByType("qresolution")->getDoubleAttr("qdamp");
+        }
+        catch (...)
+        {
+            qdamp = 0.0;
+        }
+        if (qdamp > 0.0)
+        {
+            for (size_t i = 0; i < grid.size(); ++i)
+            {
+                if (grid[i] == 0.0) continue;
+                double x, y, z;
+                indexToCoord(i, x, y, z);
+                const double r = sqrt(x * x + y * y + z * z);
+                grid[i] *= exp(-0.5 * (r * qdamp) * (r * qdamp));
+            }
+        }
+    }
+
+    size_t nonzero_count = 0;
+    for (double val : grid) {
+        if (val != 0.0) ++nonzero_count;
+    }
+    result.reserve(nonzero_count * 4);
+
+    for (size_t i = 0; i < grid.size(); ++i)
+    {
+        if (grid[i] != 0.0)
+        {
+            double x, y, z;
+            indexToCoord(i, x, y, z);
+
+            result.push_back(x);
+            result.push_back(y);
+            result.push_back(z);
+            result.push_back(grid[i]);
+        }
+    }
+    return result;
+}
+
+QuantityType PDF3DCalculator::getRadialHistogram3D() const
+{
+    QuantityType result;
+    result.reserve(mradialhistogram3d.size() * 2);
+    for (size_t i = 0; i < mradialhistogram3d.size(); ++i)
+    {
+        result.push_back(static_cast<double>(i) * mdr);
+        result.push_back(mradialhistogram3d[i]);
+    }
+    return result;
+}
+
+void PDF3DCalculator::exportGrid3DBinary(const std::string& path, bool usefloat32, bool applypost) const
+{
+    std::vector<double> grid = mgrid3d;
+    if (applypost)
+    {
+        if (musecqwindow3d) applyQWindow3D(grid);
+
+        const double rdf_scale = (mtotaloccupancy * msfaverage == 0.0) ? 0.0 :
+            1.0 / (mtotaloccupancy * msfaverage * msfaverage);
+        if (rdf_scale != 1.0)
+            for (double& val : grid) val *= rdf_scale;
+
+        if (mapplyrho0background3d)
+        {
+            const double rho0_bg = computeRho0Background();
+            if (rho0_bg != 0.0)
+                for (double& val : grid) val -= rho0_bg;
+        }
+
+        double qdamp = 0.0;
+        try { qdamp = this->getEnvelopeByType("qresolution")->getDoubleAttr("qdamp"); }
+        catch (...) { qdamp = 0.0; }
+        if (qdamp > 0.0)
+        {
+            for (size_t i = 0; i < grid.size(); ++i)
+            {
+                if (grid[i] == 0.0) continue;
+                double x, y, z;
+                indexToCoord(i, x, y, z);
+                const double r = sqrt(x * x + y * y + z * z);
+                grid[i] *= exp(-0.5 * (r * qdamp) * (r * qdamp));
+            }
+        }
+    }
+
+    std::ofstream ofs(path.c_str(), std::ios::binary | std::ios::trunc);
+    if (!ofs) throw std::runtime_error("Failed to open output file: " + path);
+
+    const size_t nxy = static_cast<size_t>(mnbins) * mnbins;
+    if (usefloat32)
+    {
+        std::vector<float> row(nxy);
+        for (int iz = 0; iz < mnbins; ++iz)
+        {
+            const size_t base = static_cast<size_t>(iz) * nxy;
+            for (size_t i = 0; i < nxy; ++i) row[i] = static_cast<float>(grid[base + i]);
+            ofs.write(reinterpret_cast<const char*>(row.data()), static_cast<std::streamsize>(nxy * sizeof(float)));
+        }
+    }
+    else
+    {
+        for (int iz = 0; iz < mnbins; ++iz)
+        {
+            const size_t base = static_cast<size_t>(iz) * nxy;
+            ofs.write(reinterpret_cast<const char*>(&grid[base]), static_cast<std::streamsize>(nxy * sizeof(double)));
+        }
+    }
+    if (!ofs) throw std::runtime_error("Failed while writing output file: " + path);
+}
+
+double PDF3DCalculator::computeRho0Background() const
+{
+    const StructureAdapterPtr& structure = this->getStructure();
+    if (!structure)  return 0.0;
+    const double partialpdfscale = this->getPartialPDFScale();
+    return mrho0backgroundscale3d * partialpdfscale * structure->numberDensity();
+}
+
+void PDF3DCalculator::applyQWindow3D(std::vector<double>& grid) const
+{
+    if (grid.empty())  return;
+
+    const double qmin = this->getQmin();
+    const double qmax = this->getQmax();
+    if (qmin <= 0.0 && qmax <= 0.0)  return;
+
+    const int n = mnbins;
+    int npad = 1;
+    while (npad < n)  npad <<= 1;
+
+    const size_t n3 = static_cast<size_t>(npad) * npad * npad;
+    std::vector<double> data(2 * n3, 0.0);
+
+    const int center = n / 2;
+    for (int iz = 0; iz < n; ++iz)
+    {
+        const int sz = (iz - center + npad) % npad;
+        for (int iy = 0; iy < n; ++iy)
+        {
+            const int sy = (iy - center + npad) % npad;
+            const size_t base_src = static_cast<size_t>(iz * n + iy) * n;
+            const size_t base_dst = static_cast<size_t>(sz * npad + sy) * npad;
+            for (int ix = 0; ix < n; ++ix)
+            {
+                const int sx = (ix - center + npad) % npad;
+                const size_t src = base_src + ix;
+                const size_t dst = base_dst + sx;
+                data[2 * dst] = grid[src];
+            }
+        }
+    }
+
+    for (int iz = 0; iz < npad; ++iz)
+    {
+        for (int iy = 0; iy < npad; ++iy)
+        {
+            double* row = &data[2 * ((iz * npad + iy) * npad)];
+            gsl_fft_complex_radix2_forward(row, 1, npad);
+        }
+    }
+
+    for (int iz = 0; iz < npad; ++iz)
+    {
+        for (int ix = 0; ix < npad; ++ix)
+        {
+            double* col = &data[2 * (iz * npad * npad + ix)];
+            gsl_fft_complex_radix2_forward(col, npad, npad);
+        }
+    }
+
+    for (int iy = 0; iy < npad; ++iy)
+    {
+        for (int ix = 0; ix < npad; ++ix)
+        {
+            double* line = &data[2 * (iy * npad + ix)];
+            gsl_fft_complex_radix2_forward(line, npad * npad, npad);
+        }
+    }
+
+    const double qstep = (npad > 0) ? (2.0 * M_PI / (npad * mdr)) : 0.0;
+    for (int iz = 0; iz < npad; ++iz)
+    {
+        const int kz = (iz <= npad / 2) ? iz : iz - npad;
+        const double qz = kz * qstep;
+        for (int iy = 0; iy < npad; ++iy)
+        {
+            const int ky = (iy <= npad / 2) ? iy : iy - npad;
+            const double qy = ky * qstep;
+            for (int ix = 0; ix < npad; ++ix)
+            {
+                const int kx = (ix <= npad / 2) ? ix : ix - npad;
+                const double qx = kx * qstep;
+                const double q = sqrt(qx * qx + qy * qy + qz * qz);
+                if ((qmax > 0.0 && q > qmax) || (qmin > 0.0 && q < qmin))
+                {
+                    const size_t idx = (static_cast<size_t>(iz) * npad + iy) * npad + ix;
+                    data[2 * idx] = 0.0;
+                    data[2 * idx + 1] = 0.0;
+                }
+            }
+        }
+    }
+
+    for (int iy = 0; iy < npad; ++iy)
+    {
+        for (int ix = 0; ix < npad; ++ix)
+        {
+            double* line = &data[2 * (iy * npad + ix)];
+            gsl_fft_complex_radix2_inverse(line, npad * npad, npad);
+        }
+    }
+
+    for (int iz = 0; iz < npad; ++iz)
+    {
+        for (int ix = 0; ix < npad; ++ix)
+        {
+            double* col = &data[2 * (iz * npad * npad + ix)];
+            gsl_fft_complex_radix2_inverse(col, npad, npad);
+        }
+    }
+
+    for (int iz = 0; iz < npad; ++iz)
+    {
+        for (int iy = 0; iy < npad; ++iy)
+        {
+            double* row = &data[2 * ((iz * npad + iy) * npad)];
+            gsl_fft_complex_radix2_inverse(row, 1, npad);
+        }
+    }
+
+    for (int iz = 0; iz < n; ++iz)
+    {
+        const int sz = (iz - center + npad) % npad;
+        for (int iy = 0; iy < n; ++iy)
+        {
+            const int sy = (iy - center + npad) % npad;
+            const size_t base_src = static_cast<size_t>(sz * npad + sy) * npad;
+            const size_t base_dst = static_cast<size_t>(iz * n + iy) * n;
+            for (int ix = 0; ix < n; ++ix)
+            {
+                const int sx = (ix - center + npad) % npad;
+                const size_t src = base_src + sx;
+                const size_t dst = base_dst + ix;
+                grid[dst] = data[2 * src];
+            }
+        }
+    }
+}
+
+// Protected Methods ---------------------------------------------------------
+
+void PDF3DCalculator::resetValue()
+{
+    const StructureAdapterPtr& structure = this->getStructure();
+    if (!structure)
+    {
+        msfCache.clear();
+        mtotaloccupancy = 0.0;
+        msfaverage = 0.0;
+    }
+    else
+    {
+        int nsite = this->countSites();
+        msfCache.resize(nsite);
+        const auto& sftable = this->getScatteringFactorTable();
+
+        mtotaloccupancy = structure->totalOccupancy();
+        double totsf = 0.0;
+        for (int i = 0; i < nsite; ++i)
+        {
+            std::string atom_type = structure->siteAtomType(i);
+            const double sf = sftable->lookup(atom_type);
+            const double occ = structure->siteOccupancy(i);
+            const double mult = structure->siteMultiplicity(i);
+            msfCache[i] = sf * occ;
+            totsf += msfCache[i] * mult;
+        }
+        msfaverage = (mtotaloccupancy == 0.0) ? 0.0 : (totsf / mtotaloccupancy);
+    }
+
+    // Ensure odd number of bins so origin is centered.
+    mnbins = static_cast<int>(2 * ceil(this->getRmax() / mdr)) + 1;
+    size_t total = static_cast<size_t>(mnbins) * mnbins * mnbins;
+    mgrid3d.assign(total, 0.0);
+    const size_t nr = static_cast<size_t>(ceil(this->getRmax() / mdr)) + 1;
+    mradialhistogram3d.assign(nr, 0.0);
+
+    PDFCalculator::resetValue();
+    if (!this->isVectorHistogramMode3D())
+    {
+        this->buildDeltaEligibleShellTable();
+        this->validateNNDelta3D();
+        this->validateDistanceDecayDelta3D();
+    }
+    if (mevaluator) mevaluator->setFlag(USEFULLSUM, true);
+}
+
+void PDF3DCalculator::addPairContribution(const BaseBondGenerator& bnds, int summationscale)
+{
+    if (bnds.distance() == 0.0) return;
+
+    int i0 = bnds.site0();
+    int i1 = bnds.site1();
+
+    if (i0 >= static_cast<int>(msfCache.size()) || i1 >= static_cast<int>(msfCache.size()))
+        return;
+
+    const R3::Vector& rvec = bnds.r01();
+    const double pairscale = bnds.multiplicity() * static_cast<double>(summationscale);
+    double sfprod = msfCache[i0] * msfCache[i1] * pairscale;
+
+    if (this->isVectorHistogramMode3D())
+    {
+        const double weight = (mhistogramweightmode3d == 1) ? pairscale : sfprod;
+        addVectorHistogramToGrid(rvec, bnds.distance(), weight);
+        return;
+    }
+
+    const R3::Matrix& U_i = bnds.Ucartesian0();
+    const R3::Matrix& U_j = bnds.Ucartesian1();
+    R3::Matrix Sigma = this->effectivePairCovariance(bnds, U_i, U_j);
+
+    addAnisotropicGaussianToGrid(rvec, Sigma, sfprod);
+}
+
+void PDF3DCalculator::addVectorHistogramToGrid(const R3::Vector& r_ij, double distance, double weight)
+{
+    if (weight == 0.0)  return;
+
+    const size_t idx = this->coordToIndex(r_ij[0], r_ij[1], r_ij[2]);
+    if (idx < mgrid3d.size())
+    {
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+        mgrid3d[idx] += weight;
+    }
+
+    if (distance >= 0.0 && !mradialhistogram3d.empty())
+    {
+        const int ir = static_cast<int>(std::lround(distance / mdr));
+        if (ir >= 0 && ir < static_cast<int>(mradialhistogram3d.size()))
+        {
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+            mradialhistogram3d[static_cast<size_t>(ir)] += weight;
+        }
+    }
+}
+
+void PDF3DCalculator::addAnisotropicGaussianToGrid(const R3::Vector& r_ij, const R3::Matrix& Sigma, double sfprod)
+{
+    // Eigenvalue decomposition
+    R3::Vector eigenvalues;
+    R3::Matrix eigenvectors;
+
+    R3::eigen_solve_3x3(Sigma, eigenvalues, eigenvectors);
+
+    // Check for positive definiteness (eigenvalues are sorted ascending)
+    if (eigenvalues[0] <= 1e-8) {
+        return;
+    }
+
+    // 3. Invert the covariance matrix
+    R3::Matrix Sigma_inv = R3::inverse(Sigma);
+    double det_Sigma = R3::determinant(Sigma);
+
+    // 4. Normalization factor
+    const double two_pi = 2.0 * M_PI;
+    double norm_factor = sfprod / (pow(two_pi, 1.5) * sqrt(det_Sigma));
+
+    // 5. Determine sampling bounding box
+    double max_sigma = 0.0;
+    for(int k=0; k<3; ++k) {
+        max_sigma = std::max(max_sigma, sqrt(eigenvalues[k]));
+    }
+
+    // 4.0 sigma cutoff
+    double cutoff_radius = 4.0 * max_sigma;
+
+    // Safety clamps
+    if (cutoff_radius < mdr) cutoff_radius = mdr;
+    if (cutoff_radius > 10.0) cutoff_radius = 10.0;
+
+    // 6. Iterate over the local grid indices
+    double halfspan = (mnbins / 2) * mdr;
+
+    auto get_index_range = [&](double center_val) -> std::pair<int, int> {
+        double min_val = center_val - cutoff_radius;
+        double max_val = center_val + cutoff_radius;
+
+        // Node-centered grid: points at k * mdr
+        int start = static_cast<int>(ceil((min_val + halfspan) / mdr));
+        int end   = static_cast<int>(floor((max_val + halfspan) / mdr));
+
+        start = std::max(0, start);
+        end   = std::min(mnbins - 1, end);
+
+        return {start, end};
+    };
+
+    std::pair<int, int> xr = get_index_range(r_ij[0]);
+    std::pair<int, int> yr = get_index_range(r_ij[1]);
+    std::pair<int, int> zr = get_index_range(r_ij[2]);
+
+    double cutoff_sq = 16.0;
+
+    const int bs = std::max(1, maccumblocksize);
+    const int nbz = (zr.second - zr.first + bs) / bs;
+    const int nby = (yr.second - yr.first + bs) / bs;
+    const int nbx = (xr.second - xr.first + bs) / bs;
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    {
+        std::vector<double> local;
+
+#ifdef _OPENMP
+#pragma omp for collapse(3) schedule(dynamic, 1)
+#endif
+        for (int tbz = 0; tbz < nbz; ++tbz)
+        {
+            for (int tby = 0; tby < nby; ++tby)
+            {
+                for (int tbx = 0; tbx < nbx; ++tbx)
+                {
+                    const int bz = zr.first + tbz * bs;
+                    const int by = yr.first + tby * bs;
+                    const int bx = xr.first + tbx * bs;
+
+                    const int izhi = std::min(zr.second, bz + bs - 1);
+                    const int iyhi = std::min(yr.second, by + bs - 1);
+                    const int ixhi = std::min(xr.second, bx + bs - 1);
+
+                    const int tz = izhi - bz + 1;
+                    const int ty = iyhi - by + 1;
+                    const int tx = ixhi - bx + 1;
+                    const size_t nloc = static_cast<size_t>(tz) * ty * tx;
+                    local.assign(nloc, 0.0);
+
+                    bool any = false;
+                    for (int iz = bz; iz <= izhi; ++iz)
+                    {
+                        const double z_grid = iz * mdr - halfspan;
+                        const double dz = z_grid - r_ij[2];
+                        for (int iy = by; iy <= iyhi; ++iy)
+                        {
+                            const double y_grid = iy * mdr - halfspan;
+                            const double dy = y_grid - r_ij[1];
+                            for (int ix = bx; ix <= ixhi; ++ix)
+                            {
+                                const double x_grid = ix * mdr - halfspan;
+                                const double dx = x_grid - r_ij[0];
+                                R3::Vector delta(dx, dy, dz);
+                                R3::Vector tmp = R3::mxvecproduct(Sigma_inv, delta);
+                                const double mahalanobis_sq = R3::dot(delta, tmp);
+                                if (mahalanobis_sq > cutoff_sq) continue;
+
+                                const double val = norm_factor * exp(-0.5 * mahalanobis_sq);
+                                const int lz = iz - bz;
+                                const int ly = iy - by;
+                                const int lx = ix - bx;
+                                const size_t lidx = (static_cast<size_t>(lz) * ty + ly) * tx + lx;
+                                local[lidx] += val;
+                                any = true;
+                            }
+                        }
+                    }
+
+                    if (!any) continue;
+
+#ifdef _OPENMP
+#pragma omp critical(pdf3d_tile_reduce)
+#endif
+                    {
+                        for (int lz = 0; lz < tz; ++lz)
+                        {
+                            const int iz = bz + lz;
+                            for (int ly = 0; ly < ty; ++ly)
+                            {
+                                const int iy = by + ly;
+                                for (int lx = 0; lx < tx; ++lx)
+                                {
+                                    const size_t lidx = (static_cast<size_t>(lz) * ty + ly) * tx + lx;
+                                    const double v = local[lidx];
+                                    if (v == 0.0) continue;
+                                    const int ix = bx + lx;
+                                    const size_t gidx = (static_cast<size_t>(iz) * mnbins + iy) * mnbins + ix;
+                                    mgrid3d[gidx] += v;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Private Helpers -----------------------------------------------------------
+
+bool PDF3DCalculator::DeltaBondKey::operator==(const DeltaBondKey& other) const
+{
+    return site0 == other.site0 && site1 == other.site1 &&
+        rx == other.rx && ry == other.ry && rz == other.rz;
+}
+
+size_t PDF3DCalculator::DeltaBondKeyHash::operator()(const DeltaBondKey& key) const
+{
+    size_t seed = 0;
+    seed ^= std::hash<int>()(key.site0) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed ^= std::hash<int>()(key.site1) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed ^= std::hash<long>()(key.rx) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed ^= std::hash<long>()(key.ry) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed ^= std::hash<long>()(key.rz) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+}
+
+bool PDF3DCalculator::matchesDeltaPairTypes(
+        const std::string& atom0, const std::string& atom1) const
+{
+    const bool allpairs = (mdeltaPairA3d == "*" && mdeltaPairB3d == "*");
+    if (allpairs)  return true;
+    const bool forward =
+        (mdeltaPairA3d == "*" || atom0 == mdeltaPairA3d) &&
+        (mdeltaPairB3d == "*" || atom1 == mdeltaPairB3d);
+    const bool reverse =
+        (mdeltaPairA3d == "*" || atom1 == mdeltaPairA3d) &&
+        (mdeltaPairB3d == "*" || atom0 == mdeltaPairB3d);
+    if (forward || reverse)  return true;
+    return (atom0 == mdeltaPairA3d && atom1 == mdeltaPairB3d) ||
+        (atom0 == mdeltaPairB3d && atom1 == mdeltaPairA3d);
+}
+
+PDF3DCalculator::DeltaBondKey
+PDF3DCalculator::makeDeltaBondKey(const BaseBondGenerator& bnds) const
+{
+    const R3::Vector& r = bnds.r01();
+    DeltaBondKey key;
+    key.site0 = bnds.site0();
+    key.site1 = bnds.site1();
+    key.rx = static_cast<long>(std::lround(r[0] / mdeltaKeyTolerance3d));
+    key.ry = static_cast<long>(std::lround(r[1] / mdeltaKeyTolerance3d));
+    key.rz = static_cast<long>(std::lround(r[2] / mdeltaKeyTolerance3d));
+    return key;
+}
+
+bool PDF3DCalculator::isDeltaEligiblePair(const BaseBondGenerator& bnds) const
+{
+    if (!menablennDelta3d || mnnDelta3d == 0.0)  return false;
+    return mdeltaEligibleBondKeys.find(this->makeDeltaBondKey(bnds)) !=
+        mdeltaEligibleBondKeys.end();
+}
+
+double PDF3DCalculator::projectedSigmaAlongBond(
+        const R3::Matrix& Sigma,
+        const R3::Vector& r,
+        double distance) const
+{
+    if (distance <= 0.0)  return 0.0;
+    R3::Vector e(r[0] / distance, r[1] / distance, r[2] / distance);
+    R3::Vector tmp = R3::mxvecproduct(Sigma, e);
+    return R3::dot(e, tmp);
+}
+
+double PDF3DCalculator::positiveDeltaBoundAlongBond(
+        const R3::Matrix& Sigma,
+        const R3::Vector& r,
+        double distance) const
+{
+    if (distance <= 0.0)  return 0.0;
+    R3::Vector e(r[0] / distance, r[1] / distance, r[2] / distance);
+
+    R3::Vector eigenvalues;
+    R3::Matrix eigenvectors;
+    R3::eigen_solve_3x3(Sigma, eigenvalues, eigenvectors);
+    if (eigenvalues[0] <= 1.0e-10)
+        return 0.0;
+
+    try
+    {
+        R3::Matrix Sigma_inv = R3::inverse(Sigma);
+        R3::Vector tmp = R3::mxvecproduct(Sigma_inv, e);
+        const double denom = R3::dot(e, tmp);
+        return (std::isfinite(denom) && denom > 0.0) ? (1.0 / denom) : 0.0;
+    }
+    catch (...)
+    {
+        return 0.0;
+    }
+}
+
+bool PDF3DCalculator::isDistanceDecayDeltaActive() const
+{
+    return menablennDelta3d &&
+        (mdistanceDelta1_3d > 0.0 || mdistanceDelta2_3d > 0.0);
+}
+
+double PDF3DCalculator::distanceDecayDeltaFraction(double distance) const
+{
+    if (distance <= 0.0)  return 0.0;
+    return mdistanceDelta1_3d / distance +
+        mdistanceDelta2_3d / (distance * distance);
+}
+
+double PDF3DCalculator::currentNNDeltaUpperBound() const
+{
+    if (mnnDelta3dUpperBound <= 0.0)  return 0.0;
+    return museadpscaleSensitivity3d ?
+        (mnnDelta3dUpperBound * madpScale3d) : mnnDelta3dUpperBound;
+}
+
+bool PDF3DCalculator::isVectorHistogramMode3D() const
+{
+    return mcalculationmode3d == 1;
+}
+
+void PDF3DCalculator::validateNNDelta3D() const
+{
+    if (this->isVectorHistogramMode3D())  return;
+    if (mnnDelta3d < 0.0)
+        throw std::invalid_argument("3D NN delta must be non-negative.");
+    if (mnnDelta3d == 0.0 || mdeltaShellRecords.empty())  return;
+    const double bound = this->currentNNDeltaUpperBound();
+    if (bound <= 0.0)
+        throw std::invalid_argument("3D NN delta cannot be positive without a positive-definite shell bound.");
+    if (mnnDelta3d >= bound)
+        throw std::invalid_argument("3D NN delta exceeds the positive-definite shell bound.");
+}
+
+void PDF3DCalculator::validateDistanceDecayDelta3D() const
+{
+    if (this->isVectorHistogramMode3D())  return;
+    if (mdistanceDelta1_3d < 0.0 || mdistanceDelta2_3d < 0.0)
+        throw std::invalid_argument("3D distance-decay delta parameters must be non-negative.");
+    if (!this->isDistanceDecayDeltaActive() || mdeltaShellRecords.empty())  return;
+
+    for (const DeltaShellRecord& record : mdeltaShellRecords)
+    {
+        if (record.distance <= 0.0)  continue;
+        const double f = this->distanceDecayDeltaFraction(record.distance);
+        if (f <= 0.0)  continue;
+        if (record.projectedSigma <= 0.0 || record.positiveDeltaBound <= 0.0)
+            continue;
+        const double delta = record.projectedSigma * f;
+        const double bound = mnnDeltaPositiveEta3d * record.positiveDeltaBound;
+        if (bound <= 0.0 || delta >= bound)
+            throw std::invalid_argument("3D distance-decay delta violates the pair positive-definite covariance bound.");
+    }
+}
+
+void PDF3DCalculator::buildDeltaEligibleShellTable()
+{
+    mdeltaEligibleBondKeys.clear();
+    mdeltaShellRecords.clear();
+    mnnDelta3dUpperBound = 0.0;
+
+    const StructureAdapterPtr& structure = this->getStructure();
+    if (!structure)  return;
+
+    BaseBondGeneratorPtr bnds = structure->createBondGenerator();
+    this->configureBondGenerator(*bnds);
+    const int cntsites = structure->countSites();
+
+    for (int i0 = 0; i0 < cntsites; ++i0)
+    {
+        bnds->selectAnchorSite(i0);
+        bnds->selectSiteRange(0, cntsites);
+        for (bnds->rewind(); !bnds->finished(); bnds->next())
+        {
+            if (bnds->distance() == 0.0)  continue;
+            const std::string& atom0 = structure->siteAtomType(bnds->site0());
+            const std::string& atom1 = structure->siteAtomType(bnds->site1());
+            if (!this->matchesDeltaPairTypes(atom0, atom1))  continue;
+
+            const R3::Vector& r = bnds->r01();
+            R3::Matrix Sigma = bnds->Ucartesian0() + bnds->Ucartesian1();
+            if (museadpscaleSensitivity3d)
+            {
+                for (int row = 0; row < 3; ++row)
+                    for (int col = 0; col < 3; ++col)
+                        Sigma(row, col) *= madpScale3d;
+            }
+            const double projected = this->projectedSigmaAlongBond(
+                    Sigma, r, bnds->distance());
+            const double positive_bound = this->positiveDeltaBoundAlongBond(
+                    Sigma, r, bnds->distance());
+
+            DeltaShellRecord record;
+            record.site0 = bnds->site0();
+            record.site1 = bnds->site1();
+            record.r01x = r[0];
+            record.r01y = r[1];
+            record.r01z = r[2];
+            record.distance = bnds->distance();
+            record.projectedSigma = projected;
+            record.positiveDeltaBound = positive_bound;
+            mdeltaShellRecords.push_back(record);
+        }
+    }
+
+    std::vector<size_t> order(mdeltaShellRecords.size());
+    for (size_t i = 0; i < order.size(); ++i)  order[i] = i;
+    std::sort(order.begin(), order.end(),
+            [&](size_t a, size_t b) {
+                return mdeltaShellRecords[a].distance < mdeltaShellRecords[b].distance;
+            });
+
+    int shell = 0;
+    double last_distance = 0.0;
+    bool first = true;
+    double min_positive_bound = std::numeric_limits<double>::infinity();
+    for (size_t idx : order)
+    {
+        const double d = mdeltaShellRecords[idx].distance;
+        if (first || d - last_distance > mdeltaShellTolerance3d)
+        {
+            ++shell;
+            first = false;
+        }
+        last_distance = d;
+        if (shell == mdeltaShellIndex3d)
+        {
+            if (mdeltaShellRecords[idx].positiveDeltaBound < min_positive_bound)
+                min_positive_bound = mdeltaShellRecords[idx].positiveDeltaBound;
+            DeltaBondKey key;
+            key.site0 = mdeltaShellRecords[idx].site0;
+            key.site1 = mdeltaShellRecords[idx].site1;
+            key.rx = static_cast<long>(std::lround(
+                        mdeltaShellRecords[idx].r01x / mdeltaKeyTolerance3d));
+            key.ry = static_cast<long>(std::lround(
+                        mdeltaShellRecords[idx].r01y / mdeltaKeyTolerance3d));
+            key.rz = static_cast<long>(std::lround(
+                        mdeltaShellRecords[idx].r01z / mdeltaKeyTolerance3d));
+            mdeltaEligibleBondKeys.insert(key);
+        }
+    }
+
+    if (min_positive_bound < std::numeric_limits<double>::infinity() &&
+        min_positive_bound > 0.0)
+    {
+        mnnDelta3dUpperBound = mnnDeltaPositiveEta3d * min_positive_bound;
+    }
+}
+
+R3::Matrix PDF3DCalculator::effectivePairCovariance(
+        const BaseBondGenerator& bnds,
+        const R3::Matrix& U_i,
+        const R3::Matrix& U_j) const
+{
+    R3::Matrix Sigma = U_i + U_j;
+    if (museadpscaleSensitivity3d)
+    {
+        for (int row = 0; row < 3; ++row)
+            for (int col = 0; col < 3; ++col)
+                Sigma(row, col) *= madpScale3d;
+    }
+
+    const double d = bnds.distance();
+    if (d <= 0.0)  return Sigma;
+
+    R3::Vector e(bnds.r01()[0] / d, bnds.r01()[1] / d, bnds.r01()[2] / d);
+    double delta_to_subtract = 0.0;
+    if (this->isDistanceDecayDeltaActive())
+    {
+        const StructureAdapterPtr& structure = this->getStructure();
+        if (!structure)  return Sigma;
+        const std::string& atom0 = structure->siteAtomType(bnds.site0());
+        const std::string& atom1 = structure->siteAtomType(bnds.site1());
+        if (!this->matchesDeltaPairTypes(atom0, atom1))  return Sigma;
+
+        const double fraction = this->distanceDecayDeltaFraction(d);
+        if (fraction <= 0.0)  return Sigma;
+        const double projected = this->projectedSigmaAlongBond(Sigma, bnds.r01(), d);
+        delta_to_subtract = projected * fraction;
+    }
+    else
+    {
+        if (!this->isDeltaEligiblePair(bnds))  return Sigma;
+        delta_to_subtract = mnnDelta3d;
+    }
+
+    if (delta_to_subtract <= 0.0)  return Sigma;
+
+    const double positive_bound = this->positiveDeltaBoundAlongBond(Sigma, bnds.r01(), d);
+    if (positive_bound <= 0.0)  return Sigma;
+
+    const double local_bound = mnnDeltaPositiveEta3d * positive_bound;
+    if (local_bound <= 0.0 || delta_to_subtract >= local_bound)
+        throw std::invalid_argument("3D delta violates the pair positive-definite covariance bound.");
+
+    for (int row = 0; row < 3; ++row)
+    {
+        for (int col = 0; col < 3; ++col)
+        {
+            Sigma(row, col) -= delta_to_subtract * e[row] * e[col];
+        }
+    }
+    return Sigma;
+}
+
+size_t PDF3DCalculator::coordToIndex(double x, double y, double z) const
+{
+    double halfspan = (mnbins / 2) * mdr;
+    if (fabs(x) > halfspan || fabs(y) > halfspan || fabs(z) > halfspan)
+        return mgrid3d.size(); // out of bounds
+
+    int ix = static_cast<int>(std::lround((x + halfspan) / mdr));
+    int iy = static_cast<int>(std::lround((y + halfspan) / mdr));
+    int iz = static_cast<int>(std::lround((z + halfspan) / mdr));
+
+    ix = std::max(0, std::min(ix, mnbins - 1));
+    iy = std::max(0, std::min(iy, mnbins - 1));
+    iz = std::max(0, std::min(iz, mnbins - 1));
+
+    return static_cast<size_t>((iz * mnbins + iy) * mnbins + ix);
+}
+
+void PDF3DCalculator::indexToCoord(size_t idx, double& x, double& y, double& z) const
+{
+    size_t iz = idx / (static_cast<size_t>(mnbins) * mnbins);
+    size_t rem = idx % (static_cast<size_t>(mnbins) * mnbins);
+    size_t iy = rem / mnbins;
+    size_t ix = rem % mnbins;
+
+    double halfspan = (mnbins / 2) * mdr;
+    x = ix * mdr - halfspan;
+    y = iy * mdr - halfspan;
+    z = iz * mdr - halfspan;
+}
+
+}   // namespace srreal
+}   // namespace diffpy
+
+#include <diffpy/serialization.ipp>
+DIFFPY_INSTANTIATE_SERIALIZATION(diffpy::srreal::PDF3DCalculator)

--- a/src/diffpy/srreal/PDF3DCalculator.hpp
+++ b/src/diffpy/srreal/PDF3DCalculator.hpp
@@ -1,0 +1,257 @@
+/*************************************************************************************
+*
+* libdiffpy         by DANSE Diffraction group
+*                   Simon J. L. Billinge
+*                   (c) 2009 The Trustees of Columbia University
+*                   in the City of New York.  All rights reserved.
+*
+* File coded by:    Hai Qiao
+*
+* See AUTHORS.txt for a list of people who contributed.
+* See LICENSE_DANSE.txt for license information.
+*
+/*************************************************************************************
+*
+* class PDF3DCalculator -- 3D real-space pair distribution function calculator
+*
+*************************************************************************************/
+
+#ifndef PDF3DCALCULATOR_HPP_INCLUDED
+#define PDF3DCALCULATOR_HPP_INCLUDED
+
+#include <diffpy/srreal/PDFCalculator.hpp>
+#include <vector>
+#include <string>
+#include <unordered_set>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+#include <diffpy/srreal/R3linalg.hpp>
+
+namespace diffpy {
+namespace srreal {
+
+class PDF3DCalculator : public PDFCalculator
+{
+public:
+    // constructor
+    PDF3DCalculator();
+
+    // Public interface to retrieve 3D PDF data
+    // Returns a flat vector of [x0, y0, z0, G0, x1, y1, z1, G1, ...]
+    QuantityType get3DPDF() const;
+
+    // Export dense 3D grid (nz, ny, nx) directly to binary file.
+    // usefloat32=true writes float32, otherwise float64.
+    // applypost=true applies q-window/rdf_scale/rho0/qdamp before export.
+    void exportGrid3DBinary(const std::string& path, bool usefloat32 = true, bool applypost = true) const;
+    QuantityType getRadialHistogram3D() const;
+
+    // Grid configuration
+    void setGridStep(double dr);
+    double getGridStep() const;
+
+    // Blocked accumulation configuration
+    void setAccumBlockSize(int bs);
+    int getAccumBlockSize() const;
+
+    void setApplyRho0Background3D(bool);
+    bool getApplyRho0Background3D() const;
+
+    void setUseCQWindow3D(bool v);
+    bool getUseCQWindow3D() const;
+
+    // Nearest-neighbor correlated-motion correction for anisotropic 3D PDF models.
+    // Boolean switches are also exposed as double attributes with 0/1
+    // values because libdiffpy's generic attribute system is double-only.
+    void setEnableNNDelta3D(bool);
+    bool getEnableNNDelta3D() const;
+    double getEnableNNDelta3DAttr() const;
+    void setEnableNNDelta3DAttr(double);
+
+    void setNNDelta3D(double);
+    const double& getNNDelta3D() const;
+    double getNNDelta3DUpperBound() const;
+    const double& getNNDeltaPositiveEta3D() const;
+    void setNNDeltaPositiveEta3D(double);
+    void setDistanceDelta1_3D(double);
+    const double& getDistanceDelta1_3D() const;
+    void setDistanceDelta2_3D(double);
+    const double& getDistanceDelta2_3D() const;
+
+    void setDeltaPairTypes3D(const std::string&, const std::string&);
+    const std::string& getDeltaPairA3D() const;
+    const std::string& getDeltaPairB3D() const;
+    void setDeltaShellIndex3D(int);
+    int getDeltaShellIndex3D() const;
+    double getDeltaShellIndex3DAttr() const;
+    void setDeltaShellIndex3DAttr(double);
+    const double& getDeltaShellTolerance3D() const;
+    void setDeltaShellTolerance3D(double);
+    const double& getDeltaKeyTolerance3D() const;
+    void setDeltaKeyTolerance3D(double);
+    int getDeltaEligiblePairCount3D() const;
+
+    void setUseADPScaleSensitivity3D(bool);
+    bool getUseADPScaleSensitivity3D() const;
+    double getUseADPScaleSensitivity3DAttr() const;
+    void setUseADPScaleSensitivity3DAttr(double);
+    void setADPScale3D(double);
+    const double& getADPScale3D() const;
+
+    void setRho0BackgroundScale3D(double);
+    const double& getRho0BackgroundScale3D() const;
+
+    void setCalculationMode3D(int);
+    int getCalculationMode3D() const;
+    double getCalculationMode3DAttr() const;
+    void setCalculationMode3DAttr(double);
+
+    void setHistogramWeightMode3D(int);
+    int getHistogramWeightMode3D() const;
+    double getHistogramWeightMode3DAttr() const;
+    void setHistogramWeightMode3DAttr(double);
+
+protected:
+    // Override PairQuantity virtual methods
+    virtual void resetValue() override;
+    virtual void addPairContribution(const BaseBondGenerator& bnds, int) override;
+
+private:
+    struct DeltaBondKey
+    {
+        int site0;
+        int site1;
+        long rx;
+        long ry;
+        long rz;
+        bool operator==(const DeltaBondKey&) const;
+    };
+
+    struct DeltaBondKeyHash
+    {
+        size_t operator()(const DeltaBondKey&) const;
+    };
+
+    struct DeltaShellRecord
+    {
+        int site0;
+        int site1;
+        double r01x;
+        double r01y;
+        double r01z;
+        double distance;
+        double projectedSigma;
+        double positiveDeltaBound;
+    };
+
+    // Helper to add anisotropic Gaussian to the grid
+    void addAnisotropicGaussianToGrid(const R3::Vector& r_ij, const R3::Matrix& Sigma, double sfprod);
+    void addVectorHistogramToGrid(const R3::Vector& r_ij, double distance, double weight);
+
+    // Helper: map 3D position to linear index
+    size_t coordToIndex(double x, double y, double z) const;
+    void indexToCoord(size_t idx, double& x, double& y, double& z) const;
+
+    void applyQWindow3D(std::vector<double>& grid) const;
+    double computeRho0Background() const;
+    void buildDeltaEligibleShellTable();
+    bool isDeltaEligiblePair(const BaseBondGenerator&) const;
+    bool matchesDeltaPairTypes(const std::string&, const std::string&) const;
+    DeltaBondKey makeDeltaBondKey(const BaseBondGenerator&) const;
+    R3::Matrix effectivePairCovariance(
+            const BaseBondGenerator&,
+            const R3::Matrix&,
+            const R3::Matrix&) const;
+    double projectedSigmaAlongBond(
+            const R3::Matrix&,
+            const R3::Vector&,
+            double distance) const;
+    double positiveDeltaBoundAlongBond(
+            const R3::Matrix&,
+            const R3::Vector&,
+            double distance) const;
+    bool isDistanceDecayDeltaActive() const;
+    double distanceDecayDeltaFraction(double distance) const;
+    void validateDistanceDecayDelta3D() const;
+    void validateNNDelta3D() const;
+    double currentNNDeltaUpperBound() const;
+    bool isVectorHistogramMode3D() const;
+
+    // Data members
+    double mdr;                      // grid spacing (assumes cubic grid centered at origin)
+    int mnbins;                      // number of bins per dimension (odd number, center at 0)
+    std::vector<double> mgrid3d;     // flattened 3D histogram (size = mnbins^3)
+    std::vector<double> mradialhistogram3d;
+    int maccumblocksize;              // block size for tiled accumulation loops
+
+    bool mapplyrho0background3d;
+    bool musecqwindow3d;
+    int mcalculationmode3d;
+    int mhistogramweightmode3d;
+
+    bool menablennDelta3d;
+    double mnnDelta3d;
+    double mnnDelta3dUpperBound;
+    double mnnDeltaPositiveEta3d;
+    double mdistanceDelta1_3d;
+    double mdistanceDelta2_3d;
+    std::string mdeltaPairA3d;
+    std::string mdeltaPairB3d;
+    int mdeltaShellIndex3d;
+    double mdeltaShellTolerance3d;
+    double mdeltaKeyTolerance3d;
+    bool museadpscaleSensitivity3d;
+    double madpScale3d;
+    double mrho0backgroundscale3d;
+    std::unordered_set<DeltaBondKey, DeltaBondKeyHash> mdeltaEligibleBondKeys;
+    std::vector<DeltaShellRecord> mdeltaShellRecords;
+
+    std::vector<double> msfCache;
+    double mtotaloccupancy;
+    double msfaverage;
+
+    // Internal constants
+    static constexpr double DEFAULT_RMAX_3D = 10.0;  // Angstrom
+    static constexpr double DEFAULT_GRID_STEP = 0.1; // Angstrom
+
+    // serialization
+    friend class boost::serialization::access;
+    template<class Archive>
+        void serialize(Archive& ar, const unsigned int version)
+    {
+        using boost::serialization::base_object;
+        ar & base_object<PDFCalculator>(*this);
+        ar & mdr;
+        ar & mnbins;
+        ar & mgrid3d;
+        ar & mradialhistogram3d;
+        ar & maccumblocksize;
+        ar & mapplyrho0background3d;
+        ar & musecqwindow3d;
+        ar & mcalculationmode3d;
+        ar & mhistogramweightmode3d;
+        ar & menablennDelta3d;
+        ar & mnnDelta3d;
+        ar & mnnDelta3dUpperBound;
+        ar & mnnDeltaPositiveEta3d;
+        ar & mdistanceDelta1_3d;
+        ar & mdistanceDelta2_3d;
+        ar & mdeltaPairA3d;
+        ar & mdeltaPairB3d;
+        ar & mdeltaShellIndex3d;
+        ar & mdeltaShellTolerance3d;
+        ar & mdeltaKeyTolerance3d;
+        ar & museadpscaleSensitivity3d;
+        ar & madpScale3d;
+        ar & mrho0backgroundscale3d;
+        ar & msfCache;
+        ar & mtotaloccupancy;
+        ar & msfaverage;
+    }
+};
+
+}   // namespace srreal
+}   // namespace diffpy
+
+#endif  // PDF3DCALCULATOR_HPP_INCLUDED

--- a/src/diffpy/srreal/PDFCalculator.cpp
+++ b/src/diffpy/srreal/PDFCalculator.cpp
@@ -677,6 +677,14 @@ double PDFCalculator::sfAverage() const
 }
 
 
+double PDFCalculator::getPartialPDFScale() const
+{
+    const double totocc = mstructure_cache.totaloccupancy;
+    return (totocc == 0.0) ? 0.0 :
+        (mstructure_cache.activeoccupancy / totocc);
+}
+
+
 void PDFCalculator::cacheStructureData()
 {
     int cntsites = this->countSites();

--- a/src/diffpy/srreal/PDFCalculator.hpp
+++ b/src/diffpy/srreal/PDFCalculator.hpp
@@ -114,6 +114,8 @@ class PDFCalculator :
         // support for PQEvaluatorOptimized
         virtual void stashPartialValue();
         virtual void restorePartialValue();
+        /// activeoccupancy / totaloccupancy used by baseline background term
+        double getPartialPDFScale() const;
 
     private:
 

--- a/src/diffpy/srreal/R3linalg.cpp
+++ b/src/diffpy/srreal/R3linalg.cpp
@@ -16,6 +16,8 @@
 *
 *****************************************************************************/
 
+#include <algorithm>
+#include <cmath>
 #include <boost/functional/hash.hpp>
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_matrix.h>
@@ -79,6 +81,88 @@ const Matrix& inverse(const Matrix& A)
     gsl_permutation_free(gP);
     gsl_matrix_free(gA);
     return B;
+}
+
+
+void eigen_solve_3x3(const Matrix& A, Vector& w, Matrix& V)
+{
+    V = identity();
+    Matrix m = A;
+
+    const int max_iter = 50;
+    const double eps = 1e-10;
+
+    for (int iter = 0; iter < max_iter; ++iter)
+    {
+        double max_off_diag = 0.0;
+        int p = 0;
+        int q = 1;
+
+        for (int i = 0; i < Ndim; ++i)
+        {
+            for (int j = i + 1; j < Ndim; ++j)
+            {
+                if (std::abs(m(i, j)) > max_off_diag)
+                {
+                    max_off_diag = std::abs(m(i, j));
+                    p = i;
+                    q = j;
+                }
+            }
+        }
+
+        if (max_off_diag < eps)  break;
+
+        double phi = 0.5 * std::atan2(
+                2.0 * m(p, q), m(q, q) - m(p, p));
+        double c = std::cos(phi);
+        double s = std::sin(phi);
+
+        double m_pp = m(p, p);
+        double m_qq = m(q, q);
+        double m_pq = m(p, q);
+
+        m(p, p) = c * c * m_pp - 2.0 * s * c * m_pq + s * s * m_qq;
+        m(q, q) = s * s * m_pp + 2.0 * s * c * m_pq + c * c * m_qq;
+        m(p, q) = 0.0;
+        m(q, p) = 0.0;
+
+        for (int i = 0; i < Ndim; ++i)
+        {
+            if (i == p || i == q)  continue;
+            double m_ip = m(i, p);
+            double m_iq = m(i, q);
+            m(i, p) = c * m_ip - s * m_iq;
+            m(p, i) = m(i, p);
+            m(i, q) = s * m_ip + c * m_iq;
+            m(q, i) = m(i, q);
+        }
+
+        for (int i = 0; i < Ndim; ++i)
+        {
+            double v_ip = V(i, p);
+            double v_iq = V(i, q);
+            V(i, p) = c * v_ip - s * v_iq;
+            V(i, q) = s * v_ip + c * v_iq;
+        }
+    }
+
+    w[0] = m(0, 0);
+    w[1] = m(1, 1);
+    w[2] = m(2, 2);
+
+    for (int i = 0; i < Ndim - 1; ++i)
+    {
+        for (int j = 0; j < Ndim - 1 - i; ++j)
+        {
+            if (w[j] <= w[j + 1])  continue;
+            std::swap(w[j], w[j + 1]);
+            for (int k = 0; k < Ndim; ++k)
+            {
+                std::swap(V(k, j), V(k, j + 1));
+            }
+        }
+    }
 }
 
 

--- a/src/diffpy/srreal/R3linalg.hpp
+++ b/src/diffpy/srreal/R3linalg.hpp
@@ -150,6 +150,8 @@ const Matrix& identity();
 const Matrix& zeromatrix();
 double determinant(const Matrix& A);
 const Matrix& inverse(const Matrix& A);
+void eigen_solve_3x3(const Matrix& A, Vector& eigenvalues,
+        Matrix& eigenvectors);
 
 const Vector& floor(const Vector&);
 template <class V> double norm(const V&);


### PR DESCRIPTION
Hi @sbillinge @dragonyanglong ,

This PR adds a CPU PDF3DCalculator implementation to libdiffpy. The calculator
produces 3D real-space PDF data on a cubic grid, exposes radial histogram data,
supports binary dense-grid export, q-window post-processing, rho0 background
scaling, and 3D covariance delta controls.

It also includes the small supporting changes needed by the calculator:
a symmetric 3x3 eigen-solver helper in R3linalg, a PDFCalculator helper for
partial PDF scale, and an ObjCryst translation-vector type compatibility fix
for builds where ObjCryst::REAL is double.

I tested the libdiffpy build locally with ObjCryst/GSL/Boost available.